### PR TITLE
feat: validate connector name

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ More configurations at [ExternalEvent Sink Connector Configurations](https://git
 To ensure idempotency, we generate a unique id
 for each request to LH with the next format: `{connector name}-{topic name}-{partition}-{offset}`.
 
+> A Connector name must be a valid hostname, meaning lowercase alphanumeric characters separated by a `-`, example `my-littlehorse-connector1`.
+> LH does not support special characters for defining WfRunIds. More at [LittleHorse Variables](https://littlehorse.io/docs/server/developer-guide/wfspec-development/basics#defining-a-wfrunvariable).
+
 ## Multiple Tasks
 
 These connectors support parallelism by running more than one task.

--- a/connector/src/main/java/io/littlehorse/connect/ExternalEventSinkConnectorConfig.java
+++ b/connector/src/main/java/io/littlehorse/connect/ExternalEventSinkConnectorConfig.java
@@ -1,13 +1,10 @@
 package io.littlehorse.connect;
 
-import com.google.common.base.Strings;
-
 import lombok.Getter;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
-import org.apache.kafka.common.config.ConfigException;
 
 import java.util.Map;
 
@@ -26,14 +23,6 @@ public class ExternalEventSinkConnectorConfig extends LHSinkConnectorConfig {
 
     public ExternalEventSinkConnectorConfig(Map<?, ?> props) {
         super(CONFIG_DEF, props);
-        externalEventName = extractExternalEventName();
-    }
-
-    private String extractExternalEventName() {
-        String externalEventName = getString(EXTERNAL_EVENT_NAME_KEY);
-        if (Strings.isNullOrEmpty(externalEventName)) {
-            throw new ConfigException(EXTERNAL_EVENT_NAME_KEY, externalEventName);
-        }
-        return externalEventName;
+        externalEventName = getString(EXTERNAL_EVENT_NAME_KEY);
     }
 }

--- a/connector/src/main/java/io/littlehorse/connect/LHSinkConnector.java
+++ b/connector/src/main/java/io/littlehorse/connect/LHSinkConnector.java
@@ -1,9 +1,15 @@
 package io.littlehorse.connect;
 
+import static org.apache.kafka.connect.runtime.ConnectorConfig.NAME_CONFIG;
+
+import com.google.common.base.Strings;
+
 import io.littlehorse.connect.util.VersionReader;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.sink.SinkConnector;
 
 import java.util.List;
@@ -40,5 +46,20 @@ public abstract class LHSinkConnector extends SinkConnector {
     public Map<String, String> getProps() {
         if (props == null) return Map.of();
         return props;
+    }
+
+    @Override
+    public Config validate(Map<String, String> connectorConfigs) {
+        String connectorName = connectorConfigs.get(NAME_CONFIG);
+        if (Strings.isNullOrEmpty(connectorName)) {
+            throw new ConfigException(NAME_CONFIG, connectorName, "Empty name is not allowed");
+        }
+        if (!connectorName.matches("[a-zA-Z0-9-]+")) {
+            throw new ConfigException(
+                    NAME_CONFIG,
+                    connectorName,
+                    "Connector name only supports alphanumeric characters and hyphens");
+        }
+        return super.validate(connectorConfigs);
     }
 }

--- a/connector/src/main/java/io/littlehorse/connect/LHSinkConnector.java
+++ b/connector/src/main/java/io/littlehorse/connect/LHSinkConnector.java
@@ -54,11 +54,11 @@ public abstract class LHSinkConnector extends SinkConnector {
         if (Strings.isNullOrEmpty(connectorName)) {
             throw new ConfigException(NAME_CONFIG, connectorName, "Empty name is not allowed");
         }
-        if (!connectorName.matches("[a-zA-Z0-9-]+")) {
+        if (!connectorName.matches("[a-z0-9-]+")) {
             throw new ConfigException(
                     NAME_CONFIG,
                     connectorName,
-                    "Connector name only supports alphanumeric characters and hyphens");
+                    "Connector name only supports lowercase alphanumeric characters and hyphens");
         }
         return super.validate(connectorConfigs);
     }

--- a/connector/src/main/java/io/littlehorse/connect/LHSinkConnectorConfig.java
+++ b/connector/src/main/java/io/littlehorse/connect/LHSinkConnectorConfig.java
@@ -148,7 +148,13 @@ public abstract class LHSinkConnectorConfig extends AbstractConfig {
     private static String extractConnectorName(Map<String, String> props) {
         String name = props.get(CONNECTOR_NAME_KEY);
         if (Strings.isNullOrEmpty(name)) {
-            throw new ConfigException(CONNECTOR_NAME_KEY, name);
+            throw new ConfigException(CONNECTOR_NAME_KEY, name, "Empty name no allowed");
+        }
+        if (!name.matches("[a-zA-Z0-9-]+")) {
+            throw new ConfigException(
+                    CONNECTOR_NAME_KEY,
+                    name,
+                    "Connector name only supports alphanumeric characters and hyphens");
         }
         return name;
     }

--- a/connector/src/main/java/io/littlehorse/connect/WfRunSinkConnectorConfig.java
+++ b/connector/src/main/java/io/littlehorse/connect/WfRunSinkConnectorConfig.java
@@ -1,13 +1,10 @@
 package io.littlehorse.connect;
 
-import com.google.common.base.Strings;
-
 import lombok.Getter;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
-import org.apache.kafka.common.config.ConfigException;
 
 import java.util.Map;
 
@@ -50,17 +47,9 @@ public class WfRunSinkConnectorConfig extends LHSinkConnectorConfig {
 
     public WfRunSinkConnectorConfig(Map<?, ?> props) {
         super(CONFIG_DEF, props);
-        wfSpecName = extractWfSpecName();
+        wfSpecName = getString(WF_SPEC_NAME_KEY);
         wfSpecRevision = getInt(WF_SPEC_REVISION_KEY);
         wfSpecMajorVersion = getInt(WF_SPEC_MAJOR_VERSION_KEY);
         wfRunParentId = getString(WF_RUN_PARENT_ID_KEY);
-    }
-
-    private String extractWfSpecName() {
-        String wfSpecName = getString(WF_SPEC_NAME_KEY);
-        if (Strings.isNullOrEmpty(wfSpecName)) {
-            throw new ConfigException(WF_SPEC_NAME_KEY, wfSpecName);
-        }
-        return wfSpecName;
     }
 }

--- a/connector/src/test/java/io/littlehorse/connect/ExternalEventSinkConnectorConfigTest.java
+++ b/connector/src/test/java/io/littlehorse/connect/ExternalEventSinkConnectorConfigTest.java
@@ -1,0 +1,42 @@
+package io.littlehorse.connect;
+
+import static io.littlehorse.connect.ExternalEventSinkConnectorConfig.EXTERNAL_EVENT_NAME_KEY;
+import static io.littlehorse.connect.LHSinkConnectorConfig.LHC_API_HOST_KEY;
+import static io.littlehorse.connect.LHSinkConnectorConfig.LHC_API_PORT_KEY;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.littlehorse.sdk.common.config.LHConfig;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+class ExternalEventSinkConnectorConfigTest {
+    @Test
+    void shouldValidateExternalEvent() {
+        assertThrows(
+                ConfigException.class,
+                () -> new ExternalEventSinkConnectorConfig(
+                        Map.of(LHC_API_HOST_KEY, "localhost", LHC_API_PORT_KEY, 2023)));
+    }
+
+    @Test
+    void shouldCreateNewConfig() {
+        ExternalEventSinkConnectorConfig connectorConfig =
+                new ExternalEventSinkConnectorConfig(Map.of(
+                        LHC_API_HOST_KEY,
+                        "localhost",
+                        LHC_API_PORT_KEY,
+                        2023,
+                        EXTERNAL_EVENT_NAME_KEY,
+                        "my-external-event"));
+        LHConfig lhConfig = connectorConfig.toLHConfig();
+        assertThat(lhConfig.getApiBootstrapHost()).isEqualTo("localhost");
+        assertThat(lhConfig.getApiBootstrapPort()).isEqualTo(Integer.valueOf(2023));
+        assertThat(lhConfig.getTenantId().getId()).isEqualTo("default");
+        assertThat(connectorConfig.getExternalEventName()).isEqualTo("my-external-event");
+    }
+}

--- a/connector/src/test/java/io/littlehorse/connect/LHSinkConnectorConfigTest.java
+++ b/connector/src/test/java/io/littlehorse/connect/LHSinkConnectorConfigTest.java
@@ -30,7 +30,7 @@ public class LHSinkConnectorConfigTest {
     public static final String EXPECTED_NAME = "my-connector";
 
     @Test
-    void shouldGenerateALHConfigObjectWithDefaultTenant() {
+    void shouldGenerateLHConfigObjectWithDefaultTenant() {
         LHSinkConnectorConfig connectorConfig = new LHSinkConnectorConfig(
                 BASE_CONFIG_DEF,
                 Map.of(
@@ -47,7 +47,22 @@ public class LHSinkConnectorConfigTest {
     }
 
     @Test
-    void shouldGenerateALHConfigObjectWithSpecificTenant() {
+    void shouldValidateConnectorName() {
+        assertThrows(
+                ConfigException.class,
+                () -> new LHSinkConnectorConfig(
+                        BASE_CONFIG_DEF,
+                        Map.of(
+                                NAME,
+                                "lh_1",
+                                LHC_API_HOST,
+                                EXPECTED_HOST,
+                                LHC_API_PORT,
+                                EXPECTED_PORT)) {});
+    }
+
+    @Test
+    void shouldGenerateLHConfigObjectWithSpecificTenant() {
         LHSinkConnectorConfig connectorConfig = new LHSinkConnectorConfig(
                 BASE_CONFIG_DEF,
                 Map.of(

--- a/connector/src/test/java/io/littlehorse/connect/LHSinkConnectorConfigTest.java
+++ b/connector/src/test/java/io/littlehorse/connect/LHSinkConnectorConfigTest.java
@@ -1,6 +1,13 @@
 package io.littlehorse.connect;
 
 import static io.littlehorse.connect.LHSinkConnectorConfig.BASE_CONFIG_DEF;
+import static io.littlehorse.connect.LHSinkConnectorConfig.LHC_API_HOST_KEY;
+import static io.littlehorse.connect.LHSinkConnectorConfig.LHC_API_PORT_KEY;
+import static io.littlehorse.connect.LHSinkConnectorConfig.LHC_API_PROTOCOL_KEY;
+import static io.littlehorse.connect.LHSinkConnectorConfig.LHC_OAUTH_ACCESS_TOKEN_URL_KEY;
+import static io.littlehorse.connect.LHSinkConnectorConfig.LHC_OAUTH_CLIENT_ID_KEY;
+import static io.littlehorse.connect.LHSinkConnectorConfig.LHC_OAUTH_CLIENT_SECRET_KEY;
+import static io.littlehorse.connect.LHSinkConnectorConfig.LHC_TENANT_ID_KEY;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -15,31 +22,15 @@ import java.util.Map;
 
 public class LHSinkConnectorConfigTest {
 
-    public static final String LHC_API_HOST = "lhc.api.host";
-    public static final String LHC_TENANT_ID = "lhc.tenant.id";
-    public static final String LHC_API_PORT = "lhc.api.port";
-    public static final String LHC_API_PROTOCOL = "lhc.api.protocol";
-    public static final String LHC_OAUTH_CLIENT_ID = "lhc.oauth.client.id";
-    public static final String LHC_OAUTH_CLIENT_SECRET = "lhc.oauth.client.secret";
-    public static final String LHC_OAUTH_ACCESS_TOKEN_URL = "lhc.oauth.access.token.url";
-    public static final String NAME = "name";
-
     public static final String EXPECTED_HOST = "localhost";
     public static final String EXPECTED_PORT = "2023";
     public static final String EXPECTED_TENANT = "my-tenant";
-    public static final String EXPECTED_NAME = "my-connector";
 
     @Test
     void shouldGenerateLHConfigObjectWithDefaultTenant() {
         LHSinkConnectorConfig connectorConfig = new LHSinkConnectorConfig(
                 BASE_CONFIG_DEF,
-                Map.of(
-                        NAME,
-                        EXPECTED_NAME,
-                        LHC_API_HOST,
-                        EXPECTED_HOST,
-                        LHC_API_PORT,
-                        EXPECTED_PORT)) {};
+                Map.of(LHC_API_HOST_KEY, EXPECTED_HOST, LHC_API_PORT_KEY, EXPECTED_PORT)) {};
         LHConfig lhConfig = connectorConfig.toLHConfig();
         assertThat(lhConfig.getApiBootstrapHost()).isEqualTo(EXPECTED_HOST);
         assertThat(lhConfig.getApiBootstrapPort()).isEqualTo(Integer.valueOf(EXPECTED_PORT));
@@ -47,32 +38,15 @@ public class LHSinkConnectorConfigTest {
     }
 
     @Test
-    void shouldValidateConnectorName() {
-        assertThrows(
-                ConfigException.class,
-                () -> new LHSinkConnectorConfig(
-                        BASE_CONFIG_DEF,
-                        Map.of(
-                                NAME,
-                                "lh_1",
-                                LHC_API_HOST,
-                                EXPECTED_HOST,
-                                LHC_API_PORT,
-                                EXPECTED_PORT)) {});
-    }
-
-    @Test
     void shouldGenerateLHConfigObjectWithSpecificTenant() {
         LHSinkConnectorConfig connectorConfig = new LHSinkConnectorConfig(
                 BASE_CONFIG_DEF,
                 Map.of(
-                        NAME,
-                        EXPECTED_NAME,
-                        LHC_API_HOST,
+                        LHC_API_HOST_KEY,
                         EXPECTED_HOST,
-                        LHC_API_PORT,
+                        LHC_API_PORT_KEY,
                         EXPECTED_PORT,
-                        LHC_TENANT_ID,
+                        LHC_TENANT_ID_KEY,
                         EXPECTED_TENANT)) {};
         LHConfig lhConfig = connectorConfig.toLHConfig();
         assertThat(lhConfig.getTenantId().getId()).isEqualTo(EXPECTED_TENANT);
@@ -83,19 +57,17 @@ public class LHSinkConnectorConfigTest {
         LHSinkConnectorConfig connectorConfig = new LHSinkConnectorConfig(
                 BASE_CONFIG_DEF,
                 Map.of(
-                        NAME,
-                        EXPECTED_NAME,
-                        LHC_API_HOST,
+                        LHC_API_HOST_KEY,
                         EXPECTED_HOST,
-                        LHC_API_PORT,
+                        LHC_API_PORT_KEY,
                         EXPECTED_PORT,
-                        LHC_API_PROTOCOL,
+                        LHC_API_PROTOCOL_KEY,
                         "TLS",
-                        LHC_OAUTH_CLIENT_ID,
+                        LHC_OAUTH_CLIENT_ID_KEY,
                         "my-client",
-                        LHC_OAUTH_CLIENT_SECRET,
+                        LHC_OAUTH_CLIENT_SECRET_KEY,
                         "my-secret",
-                        LHC_OAUTH_ACCESS_TOKEN_URL,
+                        LHC_OAUTH_ACCESS_TOKEN_URL_KEY,
                         "https://my-url.com/my-realm/token")) {};
         LHConfig lhConfig = connectorConfig.toLHConfig();
         assertThat(lhConfig.isOauth()).isTrue();
@@ -108,33 +80,29 @@ public class LHSinkConnectorConfigTest {
                 () -> new LHSinkConnectorConfig(
                         BASE_CONFIG_DEF,
                         Map.of(
-                                LHC_API_HOST,
+                                LHC_API_HOST_KEY,
                                 EXPECTED_HOST,
-                                LHC_API_PORT,
+                                LHC_API_PORT_KEY,
                                 EXPECTED_PORT,
-                                LHC_API_PROTOCOL,
+                                LHC_API_PROTOCOL_KEY,
                                 "NOT_A_PROTOCOL")) {});
         assertDoesNotThrow(() -> new LHSinkConnectorConfig(
                 BASE_CONFIG_DEF,
                 Map.of(
-                        NAME,
-                        EXPECTED_NAME,
-                        LHC_API_HOST,
+                        LHC_API_HOST_KEY,
                         EXPECTED_HOST,
-                        LHC_API_PORT,
+                        LHC_API_PORT_KEY,
                         EXPECTED_PORT,
-                        LHC_API_PROTOCOL,
+                        LHC_API_PROTOCOL_KEY,
                         "TLS")) {});
         assertDoesNotThrow(() -> new LHSinkConnectorConfig(
                 BASE_CONFIG_DEF,
                 Map.of(
-                        NAME,
-                        EXPECTED_NAME,
-                        LHC_API_HOST,
+                        LHC_API_HOST_KEY,
                         EXPECTED_HOST,
-                        LHC_API_PORT,
+                        LHC_API_PORT_KEY,
                         EXPECTED_PORT,
-                        LHC_API_PROTOCOL,
+                        LHC_API_PROTOCOL_KEY,
                         "PLAINTEXT")) {});
     }
 
@@ -146,19 +114,13 @@ public class LHSinkConnectorConfigTest {
         assertThrows(
                 ConfigException.class,
                 () -> new LHSinkConnectorConfig(
-                        BASE_CONFIG_DEF, Map.of(LHC_API_HOST, EXPECTED_HOST)) {});
+                        BASE_CONFIG_DEF, Map.of(LHC_API_HOST_KEY, EXPECTED_HOST)) {});
         assertThrows(
                 ConfigException.class,
                 () -> new LHSinkConnectorConfig(
-                        BASE_CONFIG_DEF, Map.of(LHC_API_PORT, EXPECTED_PORT)) {});
+                        BASE_CONFIG_DEF, Map.of(LHC_API_PORT_KEY, EXPECTED_PORT)) {});
         assertDoesNotThrow(() -> new LHSinkConnectorConfig(
                 BASE_CONFIG_DEF,
-                Map.of(
-                        NAME,
-                        EXPECTED_NAME,
-                        LHC_API_HOST,
-                        EXPECTED_HOST,
-                        LHC_API_PORT,
-                        EXPECTED_PORT)) {});
+                Map.of(LHC_API_HOST_KEY, EXPECTED_HOST, LHC_API_PORT_KEY, EXPECTED_PORT)) {});
     }
 }

--- a/connector/src/test/java/io/littlehorse/connect/LHSinkConnectorTest.java
+++ b/connector/src/test/java/io/littlehorse/connect/LHSinkConnectorTest.java
@@ -27,7 +27,7 @@ class LHSinkConnectorTest {
 
             @Override
             public ConfigDef config() {
-                return null;
+                return LHSinkConnectorConfig.BASE_CONFIG_DEF;
             }
         };
         connector.start(expectedMap);
@@ -38,9 +38,9 @@ class LHSinkConnectorTest {
     }
 
     @Test
-    void shouldValidateConnectorName() {
+    void shouldValidateUnderscore() {
         Map<String, String> inputMap =
-                Map.of(ConnectorConfig.NAME_CONFIG, "mi-invalid_connector-name");
+                Map.of(ConnectorConfig.NAME_CONFIG, "my_invalid_connector_name");
 
         LHSinkConnector connector = new LHSinkConnector() {
             @Override
@@ -59,6 +59,48 @@ class LHSinkConnectorTest {
 
         assertThat(configException)
                 .hasMessage(
-                        "Invalid value mi-invalid_connector-name for configuration name: Connector name only supports alphanumeric characters and hyphens");
+                        "Invalid value my_invalid_connector_name for configuration name: Connector name only supports lowercase alphanumeric characters and hyphens");
+    }
+
+    @Test
+    void shouldValidateUpperCaseName() {
+        Map<String, String> inputMap = Map.of(ConnectorConfig.NAME_CONFIG, "MyInvalidName");
+
+        LHSinkConnector connector = new LHSinkConnector() {
+            @Override
+            public Class<? extends Task> taskClass() {
+                return null;
+            }
+
+            @Override
+            public ConfigDef config() {
+                return LHSinkConnectorConfig.BASE_CONFIG_DEF;
+            }
+        };
+
+        ConfigException configException =
+                assertThrows(ConfigException.class, () -> connector.validate(inputMap));
+
+        assertThat(configException)
+                .hasMessage(
+                        "Invalid value MyInvalidName for configuration name: Connector name only supports lowercase alphanumeric characters and hyphens");
+    }
+
+    @Test
+    void shouldValidateName() {
+        Map<String, String> inputMap = Map.of(ConnectorConfig.NAME_CONFIG, "my-valid-name1");
+
+        LHSinkConnector connector = new LHSinkConnector() {
+            @Override
+            public Class<? extends Task> taskClass() {
+                return null;
+            }
+
+            @Override
+            public ConfigDef config() {
+                return LHSinkConnectorConfig.BASE_CONFIG_DEF;
+            }
+        };
+        connector.validate(inputMap);
     }
 }

--- a/connector/src/test/java/io/littlehorse/connect/LHSinkConnectorTest.java
+++ b/connector/src/test/java/io/littlehorse/connect/LHSinkConnectorTest.java
@@ -1,9 +1,12 @@
 package io.littlehorse.connect;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -32,5 +35,30 @@ class LHSinkConnectorTest {
 
         assertThat(result).hasSize(expectedSize);
         assertThat(result).containsExactly(expectedMap, expectedMap, expectedMap);
+    }
+
+    @Test
+    void shouldValidateConnectorName() {
+        Map<String, String> inputMap =
+                Map.of(ConnectorConfig.NAME_CONFIG, "mi-invalid_connector-name");
+
+        LHSinkConnector connector = new LHSinkConnector() {
+            @Override
+            public Class<? extends Task> taskClass() {
+                return null;
+            }
+
+            @Override
+            public ConfigDef config() {
+                return LHSinkConnectorConfig.BASE_CONFIG_DEF;
+            }
+        };
+
+        ConfigException configException =
+                assertThrows(ConfigException.class, () -> connector.validate(inputMap));
+
+        assertThat(configException)
+                .hasMessage(
+                        "Invalid value mi-invalid_connector-name for configuration name: Connector name only supports alphanumeric characters and hyphens");
     }
 }

--- a/connector/src/test/java/io/littlehorse/connect/WfRunSinkConnectorConfigTest.java
+++ b/connector/src/test/java/io/littlehorse/connect/WfRunSinkConnectorConfigTest.java
@@ -1,0 +1,41 @@
+package io.littlehorse.connect;
+
+import static io.littlehorse.connect.LHSinkConnectorConfig.LHC_API_HOST_KEY;
+import static io.littlehorse.connect.LHSinkConnectorConfig.LHC_API_PORT_KEY;
+import static io.littlehorse.connect.WfRunSinkConnectorConfig.WF_SPEC_NAME_KEY;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.littlehorse.sdk.common.config.LHConfig;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+class WfRunSinkConnectorConfigTest {
+    @Test
+    void shouldValidateWfSpecName() {
+        assertThrows(
+                ConfigException.class,
+                () -> new WfRunSinkConnectorConfig(
+                        Map.of(LHC_API_HOST_KEY, "localhost", LHC_API_PORT_KEY, 2023)));
+    }
+
+    @Test
+    void shouldCreateNewConfig() {
+        WfRunSinkConnectorConfig connectorConfig = new WfRunSinkConnectorConfig(Map.of(
+                LHC_API_HOST_KEY,
+                "localhost",
+                LHC_API_PORT_KEY,
+                2023,
+                WF_SPEC_NAME_KEY,
+                "my-workflow"));
+        LHConfig lhConfig = connectorConfig.toLHConfig();
+        assertThat(lhConfig.getApiBootstrapHost()).isEqualTo("localhost");
+        assertThat(lhConfig.getApiBootstrapPort()).isEqualTo(Integer.valueOf(2023));
+        assertThat(lhConfig.getTenantId().getId()).isEqualTo("default");
+        assertThat(connectorConfig.getWfSpecName()).isEqualTo("my-workflow");
+    }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -43,7 +43,7 @@
     "component_types": [
         "sink"
     ],
-    "release_date": "2025-04-01",
+    "release_date": "2025-04-25",
     "license": [
         {
             "name": "Server Side Public License, Version 1",


### PR DESCRIPTION
LH does not support special chars for WfRunIds. This PR ensures the the name of the connector only includes alphanumeric and hyphen.

These connectors use the name to generate idempotency keys for every wf run and external events.

When creating a connector with a wrong name it'll fail immediately and will show a message.

```
http :8083/connectors/example_wfrun_simple/status
HTTP/1.1 200 OK
Content-Length: 3054
Content-Type: application/json
Date: Fri, 25 Apr 2025 19:41:04 GMT
Server: Jetty(9.4.57.v20241219)

{
    "connector": {
        "state": "RUNNING",
        "worker_id": "localhost:8083"
    },
    "name": "example_wfrun_simple",
    "tasks": [
        {
            "id": 0,
            "state": "FAILED",
            "trace": "org.apache.kafka.common.config.ConfigException: Invalid value example_wfrun_simple for configuration name: Connector name only supports alphanumeric characters and hyphens\n\tat io.littlehorse.connect.LHSinkConnectorConfig.extractConnectorName(LHSinkConnectorConfig.java:154)\n\tat io.littlehorse.connect.LHSinkConnectorConfig.<init>(LHSinkConnectorConfig.java:128)\n\tat io.littlehorse.connect.WfRunSinkConnectorConfig.<init>(WfRunSinkConnectorConfig.java:52)\n\tat io.littlehorse.connect.WfRunSinkTask.configure(WfRunSinkTask.java:26)\n\tat io.littlehorse.connect.LHSinkTask.start(LHSinkTask.java:40)\n\tat org.apache.kafka.connect.runtime.WorkerSinkTask.initializeAndStart(WorkerSinkTask.java:324)\n\tat org.apache.kafka.connect.runtime.WorkerTask.doStart(WorkerTask.java:176)\n\tat org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:225)\n\tat org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:281)\n\tat org.apache.kafka.connect.runtime.isolation.Plugins.lambda$withClassLoader$1(Plugins.java:238)\n\tat java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)\n\tat java.base/java.util.concurrent.FutureTask.run(Unknown Source)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)\n\tat java.base/java.lang.Thread.run(Unknown Source)\n",
            "worker_id": "localhost:8083"
        },
        {
            "id": 1,
            "state": "FAILED",
            "trace": "org.apache.kafka.common.config.ConfigException: Invalid value example_wfrun_simple for configuration name: Connector name only supports alphanumeric characters and hyphens\n\tat io.littlehorse.connect.LHSinkConnectorConfig.extractConnectorName(LHSinkConnectorConfig.java:154)\n\tat io.littlehorse.connect.LHSinkConnectorConfig.<init>(LHSinkConnectorConfig.java:128)\n\tat io.littlehorse.connect.WfRunSinkConnectorConfig.<init>(WfRunSinkConnectorConfig.java:52)\n\tat io.littlehorse.connect.WfRunSinkTask.configure(WfRunSinkTask.java:26)\n\tat io.littlehorse.connect.LHSinkTask.start(LHSinkTask.java:40)\n\tat org.apache.kafka.connect.runtime.WorkerSinkTask.initializeAndStart(WorkerSinkTask.java:324)\n\tat org.apache.kafka.connect.runtime.WorkerTask.doStart(WorkerTask.java:176)\n\tat org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:225)\n\tat org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:281)\n\tat org.apache.kafka.connect.runtime.isolation.Plugins.lambda$withClassLoader$1(Plugins.java:238)\n\tat java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)\n\tat java.base/java.util.concurrent.FutureTask.run(Unknown Source)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)\n\tat java.base/java.lang.Thread.run(Unknown Source)\n",
            "worker_id": "localhost:8083"
        }
    ],
    "type": "sink"
}

```