### PR TITLE
feat(connector): support struct variables in connectors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,21 @@ docker compose up -d
   which resolves `STRUCT` types and caches `StructDef` lookups (including nested structs).
   Prefer it over calling `LHLibUtil.objToVarVal(...)` directly in tasks.
 - Connectors discover whether content is a `STRUCT` by reading metadata on startup
-  (`afterStart()`): `WfRunSinkTask` loads variable type defs from the `WfSpec`;
-  `ExternalEventSinkTask` and `CorrelatedEventSinkTask` load the content type from the
-  `ExternalEventDef`. If that metadata cannot be loaded the connector fails to start.
+  (`afterStart()`):
+  - `WfRunSinkTask` loads the type defs of the entrypoint thread's input variables from the
+    `WfSpec`, fetched via the `getWfSpec` gRPC (when `wf.spec.major.version` and
+    `wf.spec.revision` are set) or `getLatestWfSpec` (resolved by `wf.spec.name` and optional
+    version). Variables in child threads are not inspected.
+  - `ExternalEventSinkTask` and `CorrelatedEventSinkTask` load the content type from the
+    `ExternalEventDef`, fetched via the `getExternalEventDef` gRPC (resolved by
+    `external.event.name`). Its `type_information` field is optional, so they guard with
+    `hasTypeInformation()` before reading the return type.
+- Resolution at `put()` time is best-effort: `VariableValueMapper.toVariableValue` only builds a
+  struct when it receives a non-null `TypeDefinition` whose type is a `StructDef`. A message field
+  with no matching `STRUCT` type def (unknown variable, missing `type_information`, or a
+  non-struct type) falls back to `LHLibUtil.objToVarVal(...)` and keeps its value-inferred type.
+- If the `WfSpec`/`ExternalEventDef` itself cannot be loaded at startup, the connector fails to
+  start (so the metadata must be registered before the connector runs).
 
 ### End-to-end tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ docker compose up -d
 
 ### Struct content support
 
-- Building `VariableValue`s from message payloads goes through `util/StructValueMapper`,
+- Building `VariableValue`s from message payloads goes through `util/VariableValueMapper`,
   which resolves `STRUCT` types and caches `StructDef` lookups (including nested structs).
   Prefer it over calling `LHLibUtil.objToVarVal(...)` directly in tasks.
 - Connectors discover whether content is a `STRUCT` by reading metadata on startup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+## Project Overview
+
+`lh-kafka-connect` provides [Kafka Connect](https://docs.confluent.io/platform/current/connect/index.html)
+sink connectors that transfer data from Apache Kafka into [LittleHorse](https://littlehorse.io/).
+
+Three sink connectors are provided:
+
+- `WfRunSinkConnector` — runs `WfRun`s from Kafka records.
+- `ExternalEventSinkConnector` — posts external events.
+- `CorrelatedEventSinkConnector` — posts correlated events.
+
+## Repository Layout
+
+- `connector/` — the connectors, tasks, configs, predicates, and unit/e2e tests.
+  - `src/main/java/io/littlehorse/connect/` — production code.
+  - `src/test/java/io/littlehorse/connect/` — unit tests.
+  - `src/test/java/e2e/` — end-to-end tests (Testcontainers + Kafka Connect).
+- `common/` — shared serializers used by examples and tests.
+- `examples/` — runnable example modules, each registered in `settings.gradle` as `example-<name>`.
+- `build.gradle`, `settings.gradle`, `gradle.properties` — build configuration; dependency versions live in `gradle.properties`.
+
+## Build & Test
+
+Use the Gradle wrapper. Common commands:
+
+```shell
+./gradlew buildConfluentBundle   # build the plugin bundle
+./gradlew test                   # run unit tests
+./gradlew e2e                    # run end-to-end tests (requires docker)
+./gradlew spotlessApply          # apply code formatting
+```
+
+Local stack:
+
+```shell
+docker compose up -d
+```
+
+## Conventions
+
+- **Java 17** (source and target compatibility).
+- **Formatting**: enforced by Spotless using `palantirJavaFormat` with the `AOSP` style and removal of unused imports. Always run `./gradlew spotlessApply` before finishing.
+- **Package root**: `io.littlehorse.connect`.
+- **Dependency versions**: defined in `gradle.properties`; reference them via the `${...}Version` variables rather than hardcoding versions.
+- **Tests**: JUnit 5 with AssertJ assertions and Mockito; e2e tests use Testcontainers.
+- New example modules must be added to the list in `settings.gradle`.
+
+## Commits
+
+- Do not create commits. Instead, draft the commit message(s) and the corresponding git command(s) for the user to review and run.
+- Commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/) format (e.g. `feat(connector): add struct variable support`).
+- End each drafted commit message with an `Assisted-by:` trailer naming the model used (e.g. `Assisted-by: Claude Opus 4.8`).
+
+## Requirements
+
+- `docker` and `java` are required.
+- `pre-commit` hooks are used; install with `pre-commit install`.
+- Utilities `httpie` and `jq` are helpful for interacting with the Kafka Connect and Schema Registry REST APIs.
+
+## Documentation
+
+- `README.md` — connector usage and message structure.
+- `DEVELOPMENT.md` — local development workflow.
+- `CONFIGURATIONS.md` — connector configuration reference.
+- `COMMANDS.md` — useful commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,51 @@ docker compose up -d
 - **Tests**: JUnit 5 with AssertJ assertions and Mockito; e2e tests use Testcontainers.
 - New example modules must be added to the list in `settings.gradle`.
 
+## Architecture Notes
+
+### Sink task hierarchy
+
+- All three tasks extend the abstract `LHSinkTask`, which owns the shared `put()` loop,
+  offset handling, and error classification. Per-connector tasks implement
+  `executeGrpcCall(...)` and may override `afterStart()` for startup work (e.g. loading
+  metadata).
+- gRPC calls block the thread on purpose so records are processed sequentially per
+  partition. `ALREADY_EXISTS` is treated as a successful idempotent retry and skipped.
+
+### Error handling (transient vs. permanent)
+
+- `LHSinkTask` classifies failures via `isRetriable(Throwable)` against a `RETRIABLE_CODES`
+  set (`CANCELLED`, `DEADLINE_EXCEEDED`, `RESOURCE_EXHAUSTED`, `ABORTED`, `INTERNAL`,
+  `UNAVAILABLE`).
+- Retriable gRPC failures are rethrown as `RetriableException` so Kafka Connect retries the
+  batch — they are never sent to the DLQ, regardless of `errors.tolerance`.
+- All other failures are permanent: they honor `errors.tolerance` (fail on `none`, route to
+  the DLQ on `all`).
+- When adding code that calls the LittleHorse gRPC API, let `StatusRuntimeException` bubble
+  up so this central classifier can act on it; do not swallow it locally.
+
+### Struct content support
+
+- Building `VariableValue`s from message payloads goes through `util/StructValueMapper`,
+  which resolves `STRUCT` types and caches `StructDef` lookups (including nested structs).
+  Prefer it over calling `LHLibUtil.objToVarVal(...)` directly in tasks.
+- Connectors discover whether content is a `STRUCT` by reading metadata on startup
+  (`afterStart()`): `WfRunSinkTask` loads variable type defs from the `WfSpec`;
+  `ExternalEventSinkTask` and `CorrelatedEventSinkTask` load the content type from the
+  `ExternalEventDef`. If that metadata cannot be loaded the connector fails to start.
+
+### End-to-end tests
+
+- e2e tests live in `src/test/java/e2e/`, extend `e2e.configs.E2ETest`, and are matched by
+  the `e2e` Gradle task (separate from `test`, which excludes them).
+- Run a single e2e test with `./gradlew :connector:e2e --tests "e2e.tests.SomeTest"`. The
+  `Test` task caches results, so add `--rerun-tasks` to force a re-run after non-source
+  changes.
+- The shared LittleHorse/Kafka containers are static across the suite — avoid tests that
+  must stop or disrupt them (e.g. simulating server outages).
+- `E2ETest` provides helpers such as `registerWorkflow`, `registerStructDef`, `startWorker`,
+  `createTopics`, `produceValues`, `consumeRecords`, and `await(...)`.
+
 ## Commits
 
 - Do not create commits. Instead, draft the commit message(s) and the corresponding git command(s) for the user to review and run.

--- a/CONFIGURATIONS.md
+++ b/CONFIGURATIONS.md
@@ -36,11 +36,11 @@
   * Importance: medium
 
 ``transient.errors.tolerance``
-  How to handle records that fail with a transient (retriable) gRPC error such as network issues or the server being temporarily unavailable. When 'retry' the record is retried by Kafka Connect and never sent to the DLQ; when 'fail' the transient error is treated like any other error and handled according to the errors.tolerance setting.
+  How to handle records that fail with a transient (retriable) gRPC error such as network issues or the server being temporarily unavailable. When 'transients' the record is retried by Kafka Connect and never sent to the DLQ; when 'none' the transient error is treated like any other error and handled according to the errors.tolerance setting.
 
   * Type: string
-  * Default: retry
-  * Valid Values: [retry, fail]
+  * Default: transients
+  * Valid Values: [none, transients]
   * Importance: medium
 
 ``lhc.ca.cert``
@@ -156,11 +156,11 @@
   * Importance: medium
 
 ``transient.errors.tolerance``
-  How to handle records that fail with a transient (retriable) gRPC error such as network issues or the server being temporarily unavailable. When 'retry' the record is retried by Kafka Connect and never sent to the DLQ; when 'fail' the transient error is treated like any other error and handled according to the errors.tolerance setting.
+  How to handle records that fail with a transient (retriable) gRPC error such as network issues or the server being temporarily unavailable. When 'transients' the record is retried by Kafka Connect and never sent to the DLQ; when 'none' the transient error is treated like any other error and handled according to the errors.tolerance setting.
 
   * Type: string
-  * Default: retry
-  * Valid Values: [retry, fail]
+  * Default: transients
+  * Valid Values: [none, transients]
   * Importance: medium
 
 ``lhc.ca.cert``
@@ -255,11 +255,11 @@
   * Importance: medium
 
 ``transient.errors.tolerance``
-  How to handle records that fail with a transient (retriable) gRPC error such as network issues or the server being temporarily unavailable. When 'retry' the record is retried by Kafka Connect and never sent to the DLQ; when 'fail' the transient error is treated like any other error and handled according to the errors.tolerance setting.
+  How to handle records that fail with a transient (retriable) gRPC error such as network issues or the server being temporarily unavailable. When 'transients' the record is retried by Kafka Connect and never sent to the DLQ; when 'none' the transient error is treated like any other error and handled according to the errors.tolerance setting.
 
   * Type: string
-  * Default: retry
-  * Valid Values: [retry, fail]
+  * Default: transients
+  * Valid Values: [none, transients]
   * Importance: medium
 
 ``lhc.ca.cert``

--- a/CONFIGURATIONS.md
+++ b/CONFIGURATIONS.md
@@ -35,6 +35,14 @@
   * Default: default
   * Importance: medium
 
+``transient.errors.tolerance``
+  How to handle records that fail with a transient (retriable) gRPC error such as network issues or the server being temporarily unavailable. When 'retry' the record is retried by Kafka Connect and never sent to the DLQ; when 'fail' the transient error is treated like any other error and handled according to the errors.tolerance setting.
+
+  * Type: string
+  * Default: retry
+  * Valid Values: [retry, fail]
+  * Importance: medium
+
 ``lhc.ca.cert``
   Optional location of CA Cert file that issued the server side certificates. For TLS and mTLS connection.
 
@@ -147,6 +155,14 @@
   * Default: default
   * Importance: medium
 
+``transient.errors.tolerance``
+  How to handle records that fail with a transient (retriable) gRPC error such as network issues or the server being temporarily unavailable. When 'retry' the record is retried by Kafka Connect and never sent to the DLQ; when 'fail' the transient error is treated like any other error and handled according to the errors.tolerance setting.
+
+  * Type: string
+  * Default: retry
+  * Valid Values: [retry, fail]
+  * Importance: medium
+
 ``lhc.ca.cert``
   Optional location of CA Cert file that issued the server side certificates. For TLS and mTLS connection.
 
@@ -236,6 +252,14 @@
 
   * Type: string
   * Default: default
+  * Importance: medium
+
+``transient.errors.tolerance``
+  How to handle records that fail with a transient (retriable) gRPC error such as network issues or the server being temporarily unavailable. When 'retry' the record is retried by Kafka Connect and never sent to the DLQ; when 'fail' the transient error is treated like any other error and handled according to the errors.tolerance setting.
+
+  * Type: string
+  * Default: retry
+  * Valid Values: [retry, fail]
   * Importance: medium
 
 ``lhc.ca.cert``

--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ These connectors allow data transfer between Apache Kafka and LittleHorse.
     * [Expected Message Structure](#expected-message-structure-1)
     * [Additional Metadata](#additional-metadata-1)
     * [Quick Example](#quick-example-1)
+    * [Struct Content](#struct-content)
   * [CorrelatedEventSinkConnector](#correlatedeventsinkconnector)
     * [Expected Message Structure](#expected-message-structure-2)
     * [Additional Metadata](#additional-metadata-2)
     * [Quick Example](#quick-example-2)
+    * [Struct Content](#struct-content-1)
   * [Idempotent Writes](#idempotent-writes)
   * [Multiple Tasks](#multiple-tasks)
   * [Dead Letter Queue](#dead-letter-queue)
@@ -130,8 +132,8 @@ Produce a message whose value contains the struct fields under the variable name
 key: null, value: {"pilot":{"name":"Anakin Skywalker","vehicle":{"model":"Podracer"}}}
 ```
 
-> If the `WfSpec` cannot be loaded at startup, the connector logs a warning and treats every
-> variable as a regular type, so make sure the `WfSpec` is registered before the connector runs.
+> If the `WfSpec` cannot be loaded at startup, the connector fails to start, so make sure the
+> `WfSpec` is registered before the connector runs.
 
 ## ExternalEventSinkConnector
 
@@ -199,6 +201,31 @@ the message value will be the `Content` (more at [PutExternalEventRequest](https
 
 More configurations at [ExternalEvent Sink Connector Configurations](https://github.com/littlehorse-enterprises/lh-kafka-connect/blob/main/CONFIGURATIONS.md#externaleventsinkconnector-configurations).
 
+### Struct Content
+
+This connector supports [StructDef](https://littlehorse.io/docs/server/concepts/structs) content.
+On startup it reads the `ExternalEventDef` referenced by `external.event.name` to discover whether
+its content is a `STRUCT` type. When it is, the connector builds the LittleHorse struct from the
+message value automatically; otherwise the content keeps its regular type. No additional
+configuration is required.
+
+Given a workflow that waits for an event whose content is a `pilot` `STRUCT`:
+
+```java
+Workflow workflow = Workflow.newWorkflow("greetings", wf -> {
+    wf.execute("greet", wf.waitForEvent("set-pilot").registeredAs(Pilot.class));
+});
+```
+
+Produce a message whose value contains the struct fields:
+
+```text
+key: 64512de2a4b5470a9a8a2846b9a8a444, value: {"name":"Anakin Skywalker","vehicle":{"model":"Podracer"}}
+```
+
+> If the `ExternalEventDef` cannot be loaded at startup, the connector fails to start, so make
+> sure the `ExternalEventDef` is registered before the connector runs.
+
 ## CorrelatedEventSinkConnector
 
 ###  Expected Message Structure
@@ -260,6 +287,34 @@ the message `value` will be the `Content` (more at [PutCorrelatedEventRequest](h
 ```
 
 More configurations at [CorrelatedEvent Sink Connector Configurations](https://github.com/littlehorse-enterprises/lh-kafka-connect/blob/main/CONFIGURATIONS.md#correlatedeventsinkconnector-configurations).
+
+### Struct Content
+
+This connector supports [StructDef](https://littlehorse.io/docs/server/concepts/structs) content.
+On startup it reads the `ExternalEventDef` referenced by `external.event.name` to discover whether
+its content is a `STRUCT` type. When it is, the connector builds the LittleHorse struct from the
+message value automatically; otherwise the content keeps its regular type. No additional
+configuration is required.
+
+Given a workflow that waits for a correlated event whose content is a `pilot` `STRUCT`:
+
+```java
+Workflow workflow = Workflow.newWorkflow("greetings", wf -> {
+    WfRunVariable pilotId = wf.declareStr("pilot-id");
+    wf.execute("greet", wf.waitForEvent("set-pilot")
+            .withCorrelationId(pilotId)
+            .registeredAs(Pilot.class));
+});
+```
+
+Produce a message whose key is the `correlationId` and whose value contains the struct fields:
+
+```text
+key: 64512de2a4b5470a9a8a2846b9a8a444, value: {"name":"Anakin Skywalker","vehicle":{"model":"Podracer"}}
+```
+
+> If the `ExternalEventDef` cannot be loaded at startup, the connector fails to start, so make
+> sure the `ExternalEventDef` is registered before the connector runs.
 
 ## Idempotent Writes
 

--- a/README.md
+++ b/README.md
@@ -113,9 +113,14 @@ More configurations at [WfRun Sink Connector Configurations](https://github.com/
 
 This connector supports [StructDef](https://littlehorse.io/docs/server/concepts/structs) variables.
 On startup it reads the `WfSpec` referenced by `wf.spec.name` (honoring `wf.spec.major.version`
-and `wf.spec.revision` when provided) to discover which input variables are `STRUCT` types.
-Variables backed by a `StructDef` are built from the matching nested object in the message value,
-while every other variable keeps its regular type. No additional configuration is required.
+and `wf.spec.revision` when provided) and inspects the input variable definitions of its
+entrypoint thread to discover which variables are `STRUCT` types.
+
+When a message field matches a variable whose type is a `StructDef`, the connector builds the
+LittleHorse struct (including nested structs) from that object automatically. Any field that has
+no matching `STRUCT` variable in the `WfSpec` — including fields that do not correspond to any
+declared variable — keeps its regular, value-inferred type. No additional configuration is
+required.
 
 Given a workflow with a `pilot` `STRUCT` variable:
 
@@ -204,10 +209,12 @@ More configurations at [ExternalEvent Sink Connector Configurations](https://git
 ### Struct Content
 
 This connector supports [StructDef](https://littlehorse.io/docs/server/concepts/structs) content.
-On startup it reads the `ExternalEventDef` referenced by `external.event.name` to discover whether
-its content is a `STRUCT` type. When it is, the connector builds the LittleHorse struct from the
-message value automatically; otherwise the content keeps its regular type. No additional
-configuration is required.
+On startup it reads the `ExternalEventDef` referenced by `external.event.name` and inspects its
+type information to discover whether its content is a `STRUCT` type. When the content is a
+`StructDef`, the connector builds the LittleHorse struct (including nested structs) from the
+message value automatically. When the `ExternalEventDef` has no type information, or its content
+is not a `STRUCT`, the content keeps its regular, value-inferred type. No additional configuration
+is required.
 
 Given a workflow that waits for an event whose content is a `pilot` `STRUCT`:
 
@@ -291,10 +298,12 @@ More configurations at [CorrelatedEvent Sink Connector Configurations](https://g
 ### Struct Content
 
 This connector supports [StructDef](https://littlehorse.io/docs/server/concepts/structs) content.
-On startup it reads the `ExternalEventDef` referenced by `external.event.name` to discover whether
-its content is a `STRUCT` type. When it is, the connector builds the LittleHorse struct from the
-message value automatically; otherwise the content keeps its regular type. No additional
-configuration is required.
+On startup it reads the `ExternalEventDef` referenced by `external.event.name` and inspects its
+type information to discover whether its content is a `STRUCT` type. When the content is a
+`StructDef`, the connector builds the LittleHorse struct (including nested structs) from the
+message value automatically. When the `ExternalEventDef` has no type information, or its content
+is not a `STRUCT`, the content keeps its regular, value-inferred type. No additional configuration
+is required.
 
 Given a workflow that waits for a correlated event whose content is a `pilot` `STRUCT`:
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,36 @@ These connectors support Dead Letter Queue (DLQ).
 
 More about DLQs at [Kafka Connect Dead Letter Queue](https://docs.confluent.io/platform/current/connect/index.html#dead-letter-queue).
 
+### Error Handling
+
+These connectors distinguish between two kinds of failures so that transient
+problems do not cause data loss:
+
+- **Transient errors** are retried. When a gRPC call to LittleHorse fails with a
+  retriable status code (`CANCELLED`, `DEADLINE_EXCEEDED`, `RESOURCE_EXHAUSTED`,
+  `ABORTED`, `INTERNAL` or `UNAVAILABLE` — e.g. network issues or the server
+  being temporarily unavailable), the record is **not** sent to the DLQ. Instead
+  the connector asks Kafka Connect to retry, since the record is valid and may
+  succeed on a later attempt. This happens regardless of the `errors.tolerance`
+  setting.
+- **Permanent errors** are treated as bad records. Any other failure (e.g.
+  `INVALID_ARGUMENT`, `FAILED_PRECONDITION`, a malformed payload, or a missing
+  required field) cannot succeed on retry, so it is handled according to
+  `errors.tolerance`:
+  - `errors.tolerance=none` (default): the task fails immediately.
+  - `errors.tolerance=all`: the record is sent to the DLQ (when configured) and
+    its offset is committed so processing continues.
+
+> [!NOTE]
+> The DLQ only captures permanent errors raised while delivering records to
+> LittleHorse. Deserialization and transformation errors are routed to the DLQ
+> by Kafka Connect itself.
+
+Retry timing is controlled by the standard Kafka Connect configurations
+`errors.retry.timeout` and `errors.retry.delay.max.ms`.
+
+See the [wfrun-dlq example](examples/wfrun-dlq/README.md) for a runnable setup.
+
 ## Data Types
 
 Note that LittleHorse kernel is data type aware.  When reading data from the Kafka topic with either [WfRunSinkConnector](#wfrunsinkconnector) or [ExternalEventSinkConnector](#externaleventsinkconnector) the data types in the topic correlate with the data LittleHorse kernel expects.

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ problems do not cause data loss:
   being temporarily unavailable), the record is **not** sent to the DLQ. Instead
   the connector asks Kafka Connect to retry, since the record is valid and may
   succeed on a later attempt. This happens regardless of the `errors.tolerance`
-  setting. Set `transient.errors.tolerance=fail` (default `retry`) to instead
+  setting. Set `transient.errors.tolerance=none` (default `transients`) to instead
   treat transient errors like any other error, handling them according to
   `errors.tolerance`.
 - **Permanent errors** are treated as bad records. Any other failure (e.g.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ These connectors allow data transfer between Apache Kafka and LittleHorse.
     * [Expected Message Structure](#expected-message-structure)
     * [Additional Metadata](#additional-metadata)
     * [Quick Example](#quick-example)
+    * [Struct Variables](#struct-variables)
   * [ExternalEventSinkConnector](#externaleventsinkconnector)
     * [Expected Message Structure](#expected-message-structure-1)
     * [Additional Metadata](#additional-metadata-1)
@@ -105,6 +106,32 @@ Next connector configuration will execute `WfRuns` with the variable `name`.
 ```
 
 More configurations at [WfRun Sink Connector Configurations](https://github.com/littlehorse-enterprises/lh-kafka-connect/blob/main/CONFIGURATIONS.md#wfrunsinkconnector-configurations).
+
+### Struct Variables
+
+This connector supports [StructDef](https://littlehorse.io/docs/server/concepts/structs) variables.
+On startup it reads the `WfSpec` referenced by `wf.spec.name` (honoring `wf.spec.major.version`
+and `wf.spec.revision` when provided) to discover which input variables are `STRUCT` types.
+Variables backed by a `StructDef` are built from the matching nested object in the message value,
+while every other variable keeps its regular type. No additional configuration is required.
+
+Given a workflow with a `pilot` `STRUCT` variable:
+
+```java
+Workflow workflow = Workflow.newWorkflow("greetings", wf -> {
+    WfRunVariable pilot = wf.declareStruct("pilot", Pilot.class);
+    wf.execute("greet", pilot);
+});
+```
+
+Produce a message whose value contains the struct fields under the variable name:
+
+```text
+key: null, value: {"pilot":{"name":"Anakin Skywalker","vehicle":{"model":"Podracer"}}}
+```
+
+> If the `WfSpec` cannot be loaded at startup, the connector logs a warning and treats every
+> variable as a regular type, so make sure the `WfSpec` is registered before the connector runs.
 
 ## ExternalEventSinkConnector
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,9 @@ problems do not cause data loss:
   being temporarily unavailable), the record is **not** sent to the DLQ. Instead
   the connector asks Kafka Connect to retry, since the record is valid and may
   succeed on a later attempt. This happens regardless of the `errors.tolerance`
-  setting.
+  setting. Set `transient.errors.tolerance=fail` (default `retry`) to instead
+  treat transient errors like any other error, handling them according to
+  `errors.tolerance`.
 - **Permanent errors** are treated as bad records. Any other failure (e.g.
   `INVALID_ARGUMENT`, `FAILED_PRECONDITION`, a malformed payload, or a missing
   required field) cannot succeed on retry, so it is handled according to

--- a/connector/src/main/java/io/littlehorse/connect/CorrelatedEventSinkTask.java
+++ b/connector/src/main/java/io/littlehorse/connect/CorrelatedEventSinkTask.java
@@ -4,9 +4,11 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.littlehorse.connect.record.IdempotentSinkRecord;
 import io.littlehorse.connect.util.ObjectMapper;
-import io.littlehorse.sdk.common.LHLibUtil;
+import io.littlehorse.connect.util.StructValueMapper;
+import io.littlehorse.sdk.common.proto.ExternalEventDef;
 import io.littlehorse.sdk.common.proto.ExternalEventDefId;
 import io.littlehorse.sdk.common.proto.PutCorrelatedEventRequest;
+import io.littlehorse.sdk.common.proto.TypeDefinition;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,10 +20,26 @@ import java.util.Map;
 public class CorrelatedEventSinkTask extends LHSinkTask {
 
     private CorrelatedEventSinkConnectorConfig config;
+    private StructValueMapper structMapper;
+    private TypeDefinition contentType;
 
     @Override
     public LHSinkConnectorConfig configure(Map<String, String> props) {
         return config = new CorrelatedEventSinkConnectorConfig(props);
+    }
+
+    @Override
+    protected void afterStart() {
+        structMapper = new StructValueMapper(getBlockingStub());
+        loadContentType();
+    }
+
+    private void loadContentType() {
+        ExternalEventDef externalEventDef = getBlockingStub()
+                .getExternalEventDef(ExternalEventDefId.newBuilder()
+                        .setName(config.getExternalEventName())
+                        .build());
+        contentType = externalEventDef.getTypeInformation().getReturnType();
     }
 
     @Override
@@ -43,7 +61,8 @@ public class CorrelatedEventSinkTask extends LHSinkTask {
                         sinkRecord.correlationId() == null
                                 ? extractCorrelationId(sinkRecord.key())
                                 : sinkRecord.correlationId())
-                .setContent(LHLibUtil.objToVarVal(ObjectMapper.removeStruct(sinkRecord.value())))
+                .setContent(structMapper.toVariableValue(
+                        ObjectMapper.removeStruct(sinkRecord.value()), contentType))
                 .setExternalEventDefId(
                         ExternalEventDefId.newBuilder().setName(config.getExternalEventName()))
                 .build();

--- a/connector/src/main/java/io/littlehorse/connect/CorrelatedEventSinkTask.java
+++ b/connector/src/main/java/io/littlehorse/connect/CorrelatedEventSinkTask.java
@@ -4,7 +4,7 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.littlehorse.connect.record.IdempotentSinkRecord;
 import io.littlehorse.connect.util.ObjectMapper;
-import io.littlehorse.connect.util.StructValueMapper;
+import io.littlehorse.connect.util.VariableValueMapper;
 import io.littlehorse.sdk.common.proto.ExternalEventDef;
 import io.littlehorse.sdk.common.proto.ExternalEventDefId;
 import io.littlehorse.sdk.common.proto.PutCorrelatedEventRequest;
@@ -20,8 +20,9 @@ import java.util.Map;
 public class CorrelatedEventSinkTask extends LHSinkTask {
 
     private CorrelatedEventSinkConnectorConfig config;
-    private StructValueMapper structMapper;
+    private VariableValueMapper variableMapper;
     private TypeDefinition contentType;
+    private ObjectMapper objectMapper;
 
     @Override
     public LHSinkConnectorConfig configure(Map<String, String> props) {
@@ -30,7 +31,8 @@ public class CorrelatedEventSinkTask extends LHSinkTask {
 
     @Override
     protected void afterStart() {
-        structMapper = new StructValueMapper(getBlockingStub());
+        variableMapper = new VariableValueMapper(getBlockingStub());
+        objectMapper = new ObjectMapper();
         loadContentType();
     }
 
@@ -63,8 +65,8 @@ public class CorrelatedEventSinkTask extends LHSinkTask {
                         sinkRecord.correlationId() == null
                                 ? extractCorrelationId(sinkRecord.key())
                                 : sinkRecord.correlationId())
-                .setContent(structMapper.toVariableValue(
-                        ObjectMapper.removeStruct(sinkRecord.value()), contentType))
+                .setContent(variableMapper.toVariableValue(
+                        objectMapper.removeStruct(sinkRecord.value()), contentType))
                 .setExternalEventDefId(
                         ExternalEventDefId.newBuilder().setName(config.getExternalEventName()))
                 .build();

--- a/connector/src/main/java/io/littlehorse/connect/CorrelatedEventSinkTask.java
+++ b/connector/src/main/java/io/littlehorse/connect/CorrelatedEventSinkTask.java
@@ -39,7 +39,9 @@ public class CorrelatedEventSinkTask extends LHSinkTask {
                 .getExternalEventDef(ExternalEventDefId.newBuilder()
                         .setName(config.getExternalEventName())
                         .build());
-        contentType = externalEventDef.getTypeInformation().getReturnType();
+        if (externalEventDef.hasTypeInformation()) {
+            contentType = externalEventDef.getTypeInformation().getReturnType();
+        }
     }
 
     @Override

--- a/connector/src/main/java/io/littlehorse/connect/ExternalEventSinkTask.java
+++ b/connector/src/main/java/io/littlehorse/connect/ExternalEventSinkTask.java
@@ -4,9 +4,12 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.littlehorse.connect.record.IdempotentSinkRecord;
 import io.littlehorse.connect.util.ObjectMapper;
+import io.littlehorse.connect.util.StructValueMapper;
 import io.littlehorse.sdk.common.LHLibUtil;
+import io.littlehorse.sdk.common.proto.ExternalEventDef;
 import io.littlehorse.sdk.common.proto.ExternalEventDefId;
 import io.littlehorse.sdk.common.proto.PutExternalEventRequest;
+import io.littlehorse.sdk.common.proto.TypeDefinition;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,10 +21,26 @@ import java.util.Map;
 public class ExternalEventSinkTask extends LHSinkTask {
 
     private ExternalEventSinkConnectorConfig config;
+    private StructValueMapper structMapper;
+    private TypeDefinition contentType;
 
     @Override
     public LHSinkConnectorConfig configure(Map<String, String> props) {
         return config = new ExternalEventSinkConnectorConfig(props);
+    }
+
+    @Override
+    protected void afterStart() {
+        structMapper = new StructValueMapper(getBlockingStub());
+        loadContentType();
+    }
+
+    private void loadContentType() {
+        ExternalEventDef externalEventDef = getBlockingStub()
+                .getExternalEventDef(ExternalEventDefId.newBuilder()
+                        .setName(config.getExternalEventName())
+                        .build());
+        contentType = externalEventDef.getTypeInformation().getReturnType();
     }
 
     @Override
@@ -45,7 +64,8 @@ public class ExternalEventSinkTask extends LHSinkTask {
                         sinkRecord.wfRunId() == null
                                 ? extractWfRunId(sinkRecord.key())
                                 : sinkRecord.wfRunId()))
-                .setContent(LHLibUtil.objToVarVal(ObjectMapper.removeStruct(sinkRecord.value())))
+                .setContent(structMapper.toVariableValue(
+                        ObjectMapper.removeStruct(sinkRecord.value()), contentType))
                 .setExternalEventDefId(
                         ExternalEventDefId.newBuilder().setName(config.getExternalEventName()))
                 .build();

--- a/connector/src/main/java/io/littlehorse/connect/ExternalEventSinkTask.java
+++ b/connector/src/main/java/io/littlehorse/connect/ExternalEventSinkTask.java
@@ -4,7 +4,7 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.littlehorse.connect.record.IdempotentSinkRecord;
 import io.littlehorse.connect.util.ObjectMapper;
-import io.littlehorse.connect.util.StructValueMapper;
+import io.littlehorse.connect.util.VariableValueMapper;
 import io.littlehorse.sdk.common.LHLibUtil;
 import io.littlehorse.sdk.common.proto.ExternalEventDef;
 import io.littlehorse.sdk.common.proto.ExternalEventDefId;
@@ -21,8 +21,9 @@ import java.util.Map;
 public class ExternalEventSinkTask extends LHSinkTask {
 
     private ExternalEventSinkConnectorConfig config;
-    private StructValueMapper structMapper;
+    private VariableValueMapper variableMapper;
     private TypeDefinition contentType;
+    private ObjectMapper objectMapper;
 
     @Override
     public LHSinkConnectorConfig configure(Map<String, String> props) {
@@ -31,7 +32,8 @@ public class ExternalEventSinkTask extends LHSinkTask {
 
     @Override
     protected void afterStart() {
-        structMapper = new StructValueMapper(getBlockingStub());
+        variableMapper = new VariableValueMapper(getBlockingStub());
+        objectMapper = new ObjectMapper();
         loadContentType();
     }
 
@@ -66,8 +68,8 @@ public class ExternalEventSinkTask extends LHSinkTask {
                         sinkRecord.wfRunId() == null
                                 ? extractWfRunId(sinkRecord.key())
                                 : sinkRecord.wfRunId()))
-                .setContent(structMapper.toVariableValue(
-                        ObjectMapper.removeStruct(sinkRecord.value()), contentType))
+                .setContent(variableMapper.toVariableValue(
+                        objectMapper.removeStruct(sinkRecord.value()), contentType))
                 .setExternalEventDefId(
                         ExternalEventDefId.newBuilder().setName(config.getExternalEventName()))
                 .build();

--- a/connector/src/main/java/io/littlehorse/connect/ExternalEventSinkTask.java
+++ b/connector/src/main/java/io/littlehorse/connect/ExternalEventSinkTask.java
@@ -40,7 +40,9 @@ public class ExternalEventSinkTask extends LHSinkTask {
                 .getExternalEventDef(ExternalEventDefId.newBuilder()
                         .setName(config.getExternalEventName())
                         .build());
-        contentType = externalEventDef.getTypeInformation().getReturnType();
+        if (externalEventDef.hasTypeInformation()) {
+            contentType = externalEventDef.getTypeInformation().getReturnType();
+        }
     }
 
     @Override

--- a/connector/src/main/java/io/littlehorse/connect/LHSinkConnectorConfig.java
+++ b/connector/src/main/java/io/littlehorse/connect/LHSinkConnectorConfig.java
@@ -134,7 +134,7 @@ public abstract class LHSinkConnectorConfig extends AbstractConfig {
         super(definition, props);
     }
 
-    public boolean isRetryTransientErrors() {
+    public boolean doesTolerateTransientErrors() {
         return getString(TRANSIENT_ERRORS_TOLERANCE_KEY)
                 .equals(TRANSIENT_ERRORS_TOLERANCE_TRANSIENTS);
     }

--- a/connector/src/main/java/io/littlehorse/connect/LHSinkConnectorConfig.java
+++ b/connector/src/main/java/io/littlehorse/connect/LHSinkConnectorConfig.java
@@ -38,8 +38,8 @@ public abstract class LHSinkConnectorConfig extends AbstractConfig {
             parseKafkaConnectConfig(LHConfig.GRPC_KEEPALIVE_TIMEOUT_MS_KEY);
 
     public static final String TRANSIENT_ERRORS_TOLERANCE_KEY = "transient.errors.tolerance";
-    public static final String TRANSIENT_ERRORS_TOLERANCE_RETRY = "retry";
-    public static final String TRANSIENT_ERRORS_TOLERANCE_FAIL = "fail";
+    public static final String TRANSIENT_ERRORS_TOLERANCE_NONE = "none";
+    public static final String TRANSIENT_ERRORS_TOLERANCE_TRANSIENTS = "transients";
 
     public static final String LH_API_PROTOCOL_PLAINTEXT = "PLAINTEXT";
     public static final String LH_API_PROTOCOL_TLS = "TLS";
@@ -119,22 +119,24 @@ public abstract class LHSinkConnectorConfig extends AbstractConfig {
             .define(
                     TRANSIENT_ERRORS_TOLERANCE_KEY,
                     Type.STRING,
-                    TRANSIENT_ERRORS_TOLERANCE_RETRY,
+                    TRANSIENT_ERRORS_TOLERANCE_TRANSIENTS,
                     ConfigDef.ValidString.in(
-                            TRANSIENT_ERRORS_TOLERANCE_RETRY, TRANSIENT_ERRORS_TOLERANCE_FAIL),
+                            TRANSIENT_ERRORS_TOLERANCE_NONE, TRANSIENT_ERRORS_TOLERANCE_TRANSIENTS),
                     Importance.MEDIUM,
                     "How to handle records that fail with a transient (retriable) gRPC error such"
                             + " as network issues or the server being temporarily unavailable."
-                            + " When 'retry' the record is retried by Kafka Connect and never sent"
-                            + " to the DLQ; when 'fail' the transient error is treated like any"
-                            + " other error and handled according to the errors.tolerance setting.");
+                            + " When 'transients' the record is retried by Kafka Connect and never"
+                            + " sent to the DLQ; when 'none' the transient error is treated like"
+                            + " any other error and handled according to the errors.tolerance"
+                            + " setting.");
 
     public LHSinkConnectorConfig(ConfigDef definition, Map<?, ?> props) {
         super(definition, props);
     }
 
     public boolean isRetryTransientErrors() {
-        return getString(TRANSIENT_ERRORS_TOLERANCE_KEY).equals(TRANSIENT_ERRORS_TOLERANCE_RETRY);
+        return getString(TRANSIENT_ERRORS_TOLERANCE_KEY)
+                .equals(TRANSIENT_ERRORS_TOLERANCE_TRANSIENTS);
     }
 
     private static String parseKafkaConnectConfig(String key) {

--- a/connector/src/main/java/io/littlehorse/connect/LHSinkConnectorConfig.java
+++ b/connector/src/main/java/io/littlehorse/connect/LHSinkConnectorConfig.java
@@ -37,6 +37,10 @@ public abstract class LHSinkConnectorConfig extends AbstractConfig {
     public static final String LHC_GRPC_KEEPALIVE_TIMEOUT_MS_KEY =
             parseKafkaConnectConfig(LHConfig.GRPC_KEEPALIVE_TIMEOUT_MS_KEY);
 
+    public static final String TRANSIENT_ERRORS_TOLERANCE_KEY = "transient.errors.tolerance";
+    public static final String TRANSIENT_ERRORS_TOLERANCE_RETRY = "retry";
+    public static final String TRANSIENT_ERRORS_TOLERANCE_FAIL = "fail";
+
     public static final String LH_API_PROTOCOL_PLAINTEXT = "PLAINTEXT";
     public static final String LH_API_PROTOCOL_TLS = "TLS";
 
@@ -111,10 +115,26 @@ public abstract class LHSinkConnectorConfig extends AbstractConfig {
                     Type.LONG,
                     Duration.ofSeconds(5).toMillis(),
                     Importance.LOW,
-                    "Time in milliseconds to configure the timeout for the keepalive pings on the grpc client.");
+                    "Time in milliseconds to configure the timeout for the keepalive pings on the grpc client.")
+            .define(
+                    TRANSIENT_ERRORS_TOLERANCE_KEY,
+                    Type.STRING,
+                    TRANSIENT_ERRORS_TOLERANCE_RETRY,
+                    ConfigDef.ValidString.in(
+                            TRANSIENT_ERRORS_TOLERANCE_RETRY, TRANSIENT_ERRORS_TOLERANCE_FAIL),
+                    Importance.MEDIUM,
+                    "How to handle records that fail with a transient (retriable) gRPC error such"
+                            + " as network issues or the server being temporarily unavailable."
+                            + " When 'retry' the record is retried by Kafka Connect and never sent"
+                            + " to the DLQ; when 'fail' the transient error is treated like any"
+                            + " other error and handled according to the errors.tolerance setting.");
 
     public LHSinkConnectorConfig(ConfigDef definition, Map<?, ?> props) {
         super(definition, props);
+    }
+
+    public boolean isRetryTransientErrors() {
+        return getString(TRANSIENT_ERRORS_TOLERANCE_KEY).equals(TRANSIENT_ERRORS_TOLERANCE_RETRY);
     }
 
     private static String parseKafkaConnectConfig(String key) {

--- a/connector/src/main/java/io/littlehorse/connect/LHSinkTask.java
+++ b/connector/src/main/java/io/littlehorse/connect/LHSinkTask.java
@@ -4,6 +4,8 @@ import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_
 import static org.apache.kafka.connect.runtime.ConnectorConfig.NAME_CONFIG;
 
 import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.littlehorse.connect.record.IdempotentSinkRecord;
 import io.littlehorse.connect.util.VersionReader;
 import io.littlehorse.sdk.common.config.LHConfig;
@@ -14,18 +16,34 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Getter
 public abstract class LHSinkTask extends SinkTask {
+    /**
+     * gRPC status codes that represent transient failures (e.g. network issues, server
+     * unavailable or overloaded). Errors with these codes are retried instead of being sent to
+     * the DLQ, since the record itself is valid and could succeed on a later attempt.
+     */
+    private static final Set<Status.Code> RETRIABLE_CODES = EnumSet.of(
+            Status.Code.CANCELLED,
+            Status.Code.DEADLINE_EXCEEDED,
+            Status.Code.RESOURCE_EXHAUSTED,
+            Status.Code.ABORTED,
+            Status.Code.INTERNAL,
+            Status.Code.UNAVAILABLE);
+
     private final Map<TopicPartition, OffsetAndMetadata> successfulOffsets = new HashMap<>();
 
     private LHSinkConnectorConfig connectorConfig;
@@ -110,12 +128,26 @@ public abstract class LHSinkTask extends SinkTask {
                         connectorName,
                         e);
 
+                if (isRetriable(e)) {
+                    // transient failure: let Kafka Connect retry the batch instead of
+                    // discarding a valid record (no DLQ, no offset commit)
+                    log.debug(
+                            "Retrying record [topic={}, partition={}, offset={}] for task {}[{}]"
+                                    + " after transient error",
+                            sinkRecord.topic(),
+                            sinkRecord.kafkaPartition(),
+                            sinkRecord.kafkaOffset(),
+                            getClass().getSimpleName(),
+                            connectorName);
+                    throw new RetriableException(e);
+                }
+
                 if (!doesTolerateErrors()) {
                     // full stop
                     throw e;
                 }
 
-                // send error to the dlq
+                // permanent failure: send error to the dlq
                 report(sinkRecord, e);
                 // commit if it tolerates errors
                 updateSuccessfulOffsets(sinkRecord);
@@ -178,6 +210,13 @@ public abstract class LHSinkTask extends SinkTask {
 
     private boolean doesTolerateErrors() {
         return errorsTolerance.equals("all");
+    }
+
+    private boolean isRetriable(Throwable e) {
+        if (e instanceof StatusRuntimeException grpcException) {
+            return RETRIABLE_CODES.contains(grpcException.getStatus().getCode());
+        }
+        return false;
     }
 
     private boolean isDLQEnabled() {

--- a/connector/src/main/java/io/littlehorse/connect/LHSinkTask.java
+++ b/connector/src/main/java/io/littlehorse/connect/LHSinkTask.java
@@ -58,7 +58,14 @@ public abstract class LHSinkTask extends SinkTask {
                 getClass().getSimpleName(),
                 connectorName,
                 isDLQEnabled() ? "enabled" : "disabled");
+        afterStart();
     }
+
+    /**
+     * Hook invoked at the end of {@link #start(Map)}, once the config and blocking stub are
+     * ready. Subclasses may override it to perform additional initialization.
+     */
+    protected void afterStart() {}
 
     @Override
     public void stop() {

--- a/connector/src/main/java/io/littlehorse/connect/LHSinkTask.java
+++ b/connector/src/main/java/io/littlehorse/connect/LHSinkTask.java
@@ -128,7 +128,7 @@ public abstract class LHSinkTask extends SinkTask {
                         connectorName,
                         e);
 
-                if (isRetriable(e)) {
+                if (isRetryTransientErrors() && isRetriable(e)) {
                     // transient failure: let Kafka Connect retry the batch instead of
                     // discarding a valid record (no DLQ, no offset commit)
                     log.debug(
@@ -217,6 +217,10 @@ public abstract class LHSinkTask extends SinkTask {
             return RETRIABLE_CODES.contains(grpcException.getStatus().getCode());
         }
         return false;
+    }
+
+    private boolean isRetryTransientErrors() {
+        return connectorConfig.isRetryTransientErrors();
     }
 
     private boolean isDLQEnabled() {

--- a/connector/src/main/java/io/littlehorse/connect/LHSinkTask.java
+++ b/connector/src/main/java/io/littlehorse/connect/LHSinkTask.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.RetriableException;
+import org.apache.kafka.connect.runtime.errors.ToleranceType;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 
@@ -50,7 +51,7 @@ public abstract class LHSinkTask extends SinkTask {
     private LittleHorseBlockingStub blockingStub;
     private LHConfig lhConfig;
     private String connectorName;
-    private String errorsTolerance;
+    private ToleranceType errorsTolerance;
 
     public abstract void executeGrpcCall(IdempotentSinkRecord sinkRecord);
 
@@ -67,7 +68,9 @@ public abstract class LHSinkTask extends SinkTask {
                         NAME_CONFIG,
                         "lh-connector-" + UUID.randomUUID().toString().replace("-", ""))
                 .trim();
-        errorsTolerance = props.getOrDefault(ERRORS_TOLERANCE_CONFIG, "none");
+        errorsTolerance = ToleranceType.valueOf(
+                props.getOrDefault(ERRORS_TOLERANCE_CONFIG, ToleranceType.NONE.value())
+                        .toUpperCase());
         connectorConfig = configure(props);
         lhConfig = connectorConfig.toLHConfig();
         blockingStub = lhConfig.getBlockingStub();
@@ -128,7 +131,7 @@ public abstract class LHSinkTask extends SinkTask {
                         connectorName,
                         e);
 
-                if (isRetryTransientErrors() && isRetriable(e)) {
+                if (doesTolerateTransientErrors() && isRetriable(e)) {
                     // transient failure: let Kafka Connect retry the batch instead of
                     // discarding a valid record (no DLQ, no offset commit)
                     log.debug(
@@ -209,7 +212,7 @@ public abstract class LHSinkTask extends SinkTask {
     }
 
     private boolean doesTolerateErrors() {
-        return errorsTolerance.equals("all");
+        return errorsTolerance == ToleranceType.ALL;
     }
 
     private boolean isRetriable(Throwable e) {
@@ -219,8 +222,8 @@ public abstract class LHSinkTask extends SinkTask {
         return false;
     }
 
-    private boolean isRetryTransientErrors() {
-        return connectorConfig.isRetryTransientErrors();
+    private boolean doesTolerateTransientErrors() {
+        return connectorConfig.doesTolerateTransientErrors();
     }
 
     private boolean isDLQEnabled() {

--- a/connector/src/main/java/io/littlehorse/connect/WfRunSinkTask.java
+++ b/connector/src/main/java/io/littlehorse/connect/WfRunSinkTask.java
@@ -5,25 +5,82 @@ import io.grpc.StatusRuntimeException;
 import io.littlehorse.connect.record.IdempotentSinkRecord;
 import io.littlehorse.connect.util.ObjectMapper;
 import io.littlehorse.sdk.common.LHLibUtil;
+import io.littlehorse.sdk.common.proto.GetLatestWfSpecRequest;
+import io.littlehorse.sdk.common.proto.InlineStruct;
+import io.littlehorse.sdk.common.proto.InlineStructDef;
 import io.littlehorse.sdk.common.proto.RunWfRequest;
+import io.littlehorse.sdk.common.proto.StructDef;
+import io.littlehorse.sdk.common.proto.StructDefId;
+import io.littlehorse.sdk.common.proto.StructField;
+import io.littlehorse.sdk.common.proto.StructFieldDef;
+import io.littlehorse.sdk.common.proto.ThreadSpec;
+import io.littlehorse.sdk.common.proto.ThreadVarDef;
+import io.littlehorse.sdk.common.proto.TypeDefinition;
+import io.littlehorse.sdk.common.proto.VariableDef;
 import io.littlehorse.sdk.common.proto.VariableValue;
+import io.littlehorse.sdk.common.proto.WfSpec;
+import io.littlehorse.sdk.common.proto.WfSpecId;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Slf4j
 public class WfRunSinkTask extends LHSinkTask {
 
     private WfRunSinkConnectorConfig config;
+    private final Map<String, TypeDefinition> variableTypeDefs = new HashMap<>();
+    private final Map<StructDefId, StructDef> structDefCache = new HashMap<>();
 
     @Override
     public LHSinkConnectorConfig configure(Map<String, String> props) {
         return config = new WfRunSinkConnectorConfig(props);
+    }
+
+    @Override
+    protected void afterStart() {
+        loadVariableTypeDefs();
+    }
+
+    private void loadVariableTypeDefs() {
+        try {
+            WfSpec wfSpec = fetchWfSpec();
+            ThreadSpec entrypoint = wfSpec.getThreadSpecsOrThrow(wfSpec.getEntrypointThreadName());
+
+            for (ThreadVarDef threadVarDef : entrypoint.getVariableDefsList()) {
+                VariableDef varDef = threadVarDef.getVarDef();
+                variableTypeDefs.put(varDef.getName(), varDef.getTypeDef());
+            }
+        } catch (StatusRuntimeException grpcException) {
+            log.warn(
+                    "Could not load WfSpec '{}' to resolve variable types; struct variables may not be detected",
+                    config.getWfSpecName(),
+                    grpcException);
+        }
+    }
+
+    private WfSpec fetchWfSpec() {
+        if (config.getWfSpecMajorVersion() != null && config.getWfSpecRevision() != null) {
+            WfSpecId wfSpecId = WfSpecId.newBuilder()
+                    .setName(config.getWfSpecName())
+                    .setMajorVersion(config.getWfSpecMajorVersion())
+                    .setRevision(config.getWfSpecRevision())
+                    .build();
+            return getBlockingStub().getWfSpec(wfSpecId);
+        }
+
+        GetLatestWfSpecRequest.Builder request =
+                GetLatestWfSpecRequest.newBuilder().setName(config.getWfSpecName());
+
+        if (config.getWfSpecMajorVersion() != null) {
+            request.setMajorVersion(config.getWfSpecMajorVersion());
+        }
+
+        return getBlockingStub().getLatestWfSpec(request.build());
     }
 
     @Override
@@ -76,9 +133,55 @@ public class WfRunSinkTask extends LHSinkTask {
         }
 
         Map<String, Object> variables = (Map<String, Object>) ObjectMapper.removeStruct(value);
-        return variables.entrySet().stream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey, entry -> LHLibUtil.objToVarVal(entry.getValue())));
+        Map<String, VariableValue> result = new HashMap<>();
+        for (Map.Entry<String, Object> entry : variables.entrySet()) {
+            result.put(entry.getKey(), buildVariableValue(entry.getKey(), entry.getValue()));
+        }
+        return result;
+    }
+
+    private VariableValue buildVariableValue(String name, Object value) {
+        TypeDefinition typeDef = variableTypeDefs.get(name);
+        if (typeDef != null && typeDef.hasStructDefId()) {
+            return buildStructValue(value, typeDef.getStructDefId());
+        }
+        return LHLibUtil.objToVarVal(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private VariableValue buildStructValue(Object value, StructDefId structDefId) {
+        if (value == null) {
+            return VariableValue.newBuilder().build();
+        }
+
+        if (!(value instanceof Map)) {
+            throw new DataException("Expected schema structure not provided, struct variable '"
+                    + structDefId.getName() + "' should be a key-value pair data set");
+        }
+
+        Map<String, Object> fields = (Map<String, Object>) value;
+        InlineStructDef structDef = getStructDef(structDefId).getStructDef();
+        InlineStruct.Builder inlineStruct = InlineStruct.newBuilder();
+
+        for (Map.Entry<String, StructFieldDef> field : structDef.getFieldsMap().entrySet()) {
+            String fieldName = field.getKey();
+            TypeDefinition fieldType = field.getValue().getFieldType();
+            Object fieldValue = fields.get(fieldName);
+
+            VariableValue fieldVarVal = fieldType.hasStructDefId()
+                    ? buildStructValue(fieldValue, fieldType.getStructDefId())
+                    : LHLibUtil.objToVarVal(fieldValue);
+
+            inlineStruct.putFields(
+                    fieldName, StructField.newBuilder().setValue(fieldVarVal).build());
+        }
+
+        return LHLibUtil.inlineStructToVarVal(inlineStruct.build(), structDefId);
+    }
+
+    private StructDef getStructDef(StructDefId structDefId) {
+        return structDefCache.computeIfAbsent(
+                structDefId, id -> getBlockingStub().getStructDef(id));
     }
 
     private String extractWfRunId(IdempotentSinkRecord sinkRecord) {

--- a/connector/src/main/java/io/littlehorse/connect/WfRunSinkTask.java
+++ b/connector/src/main/java/io/littlehorse/connect/WfRunSinkTask.java
@@ -4,7 +4,7 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.littlehorse.connect.record.IdempotentSinkRecord;
 import io.littlehorse.connect.util.ObjectMapper;
-import io.littlehorse.connect.util.StructValueMapper;
+import io.littlehorse.connect.util.VariableValueMapper;
 import io.littlehorse.sdk.common.LHLibUtil;
 import io.littlehorse.sdk.common.proto.GetLatestWfSpecRequest;
 import io.littlehorse.sdk.common.proto.RunWfRequest;
@@ -29,7 +29,8 @@ public class WfRunSinkTask extends LHSinkTask {
 
     private WfRunSinkConnectorConfig config;
     private final Map<String, TypeDefinition> variableTypeDefs = new HashMap<>();
-    private StructValueMapper structMapper;
+    private ObjectMapper objectMapper;
+    private VariableValueMapper variableMapper;
 
     @Override
     public LHSinkConnectorConfig configure(Map<String, String> props) {
@@ -38,7 +39,8 @@ public class WfRunSinkTask extends LHSinkTask {
 
     @Override
     protected void afterStart() {
-        structMapper = new StructValueMapper(getBlockingStub());
+        variableMapper = new VariableValueMapper(getBlockingStub());
+        objectMapper = new ObjectMapper();
         loadVariableTypeDefs();
     }
 
@@ -121,7 +123,7 @@ public class WfRunSinkTask extends LHSinkTask {
                     "Expected schema structure not provided, it should be a key-value pair data set");
         }
 
-        Map<String, Object> variables = (Map<String, Object>) ObjectMapper.removeStruct(value);
+        Map<String, Object> variables = (Map<String, Object>) objectMapper.removeStruct(value);
         Map<String, VariableValue> result = new HashMap<>();
         for (Map.Entry<String, Object> entry : variables.entrySet()) {
             result.put(entry.getKey(), buildVariableValue(entry.getKey(), entry.getValue()));
@@ -130,7 +132,7 @@ public class WfRunSinkTask extends LHSinkTask {
     }
 
     private VariableValue buildVariableValue(String name, Object value) {
-        return structMapper.toVariableValue(value, variableTypeDefs.get(name));
+        return variableMapper.toVariableValue(value, variableTypeDefs.get(name));
     }
 
     private String extractWfRunId(IdempotentSinkRecord sinkRecord) {

--- a/connector/src/main/java/io/littlehorse/connect/WfRunSinkTask.java
+++ b/connector/src/main/java/io/littlehorse/connect/WfRunSinkTask.java
@@ -4,15 +4,10 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.littlehorse.connect.record.IdempotentSinkRecord;
 import io.littlehorse.connect.util.ObjectMapper;
+import io.littlehorse.connect.util.StructValueMapper;
 import io.littlehorse.sdk.common.LHLibUtil;
 import io.littlehorse.sdk.common.proto.GetLatestWfSpecRequest;
-import io.littlehorse.sdk.common.proto.InlineStruct;
-import io.littlehorse.sdk.common.proto.InlineStructDef;
 import io.littlehorse.sdk.common.proto.RunWfRequest;
-import io.littlehorse.sdk.common.proto.StructDef;
-import io.littlehorse.sdk.common.proto.StructDefId;
-import io.littlehorse.sdk.common.proto.StructField;
-import io.littlehorse.sdk.common.proto.StructFieldDef;
 import io.littlehorse.sdk.common.proto.ThreadSpec;
 import io.littlehorse.sdk.common.proto.ThreadVarDef;
 import io.littlehorse.sdk.common.proto.TypeDefinition;
@@ -34,7 +29,7 @@ public class WfRunSinkTask extends LHSinkTask {
 
     private WfRunSinkConnectorConfig config;
     private final Map<String, TypeDefinition> variableTypeDefs = new HashMap<>();
-    private final Map<StructDefId, StructDef> structDefCache = new HashMap<>();
+    private StructValueMapper structMapper;
 
     @Override
     public LHSinkConnectorConfig configure(Map<String, String> props) {
@@ -43,23 +38,17 @@ public class WfRunSinkTask extends LHSinkTask {
 
     @Override
     protected void afterStart() {
+        structMapper = new StructValueMapper(getBlockingStub());
         loadVariableTypeDefs();
     }
 
     private void loadVariableTypeDefs() {
-        try {
-            WfSpec wfSpec = fetchWfSpec();
-            ThreadSpec entrypoint = wfSpec.getThreadSpecsOrThrow(wfSpec.getEntrypointThreadName());
+        WfSpec wfSpec = fetchWfSpec();
+        ThreadSpec entrypoint = wfSpec.getThreadSpecsOrThrow(wfSpec.getEntrypointThreadName());
 
-            for (ThreadVarDef threadVarDef : entrypoint.getVariableDefsList()) {
-                VariableDef varDef = threadVarDef.getVarDef();
-                variableTypeDefs.put(varDef.getName(), varDef.getTypeDef());
-            }
-        } catch (StatusRuntimeException grpcException) {
-            log.warn(
-                    "Could not load WfSpec '{}' to resolve variable types; struct variables may not be detected",
-                    config.getWfSpecName(),
-                    grpcException);
+        for (ThreadVarDef threadVarDef : entrypoint.getVariableDefsList()) {
+            VariableDef varDef = threadVarDef.getVarDef();
+            variableTypeDefs.put(varDef.getName(), varDef.getTypeDef());
         }
     }
 
@@ -141,47 +130,7 @@ public class WfRunSinkTask extends LHSinkTask {
     }
 
     private VariableValue buildVariableValue(String name, Object value) {
-        TypeDefinition typeDef = variableTypeDefs.get(name);
-        if (typeDef != null && typeDef.hasStructDefId()) {
-            return buildStructValue(value, typeDef.getStructDefId());
-        }
-        return LHLibUtil.objToVarVal(value);
-    }
-
-    @SuppressWarnings("unchecked")
-    private VariableValue buildStructValue(Object value, StructDefId structDefId) {
-        if (value == null) {
-            return VariableValue.newBuilder().build();
-        }
-
-        if (!(value instanceof Map)) {
-            throw new DataException("Expected schema structure not provided, struct variable '"
-                    + structDefId.getName() + "' should be a key-value pair data set");
-        }
-
-        Map<String, Object> fields = (Map<String, Object>) value;
-        InlineStructDef structDef = getStructDef(structDefId).getStructDef();
-        InlineStruct.Builder inlineStruct = InlineStruct.newBuilder();
-
-        for (Map.Entry<String, StructFieldDef> field : structDef.getFieldsMap().entrySet()) {
-            String fieldName = field.getKey();
-            TypeDefinition fieldType = field.getValue().getFieldType();
-            Object fieldValue = fields.get(fieldName);
-
-            VariableValue fieldVarVal = fieldType.hasStructDefId()
-                    ? buildStructValue(fieldValue, fieldType.getStructDefId())
-                    : LHLibUtil.objToVarVal(fieldValue);
-
-            inlineStruct.putFields(
-                    fieldName, StructField.newBuilder().setValue(fieldVarVal).build());
-        }
-
-        return LHLibUtil.inlineStructToVarVal(inlineStruct.build(), structDefId);
-    }
-
-    private StructDef getStructDef(StructDefId structDefId) {
-        return structDefCache.computeIfAbsent(
-                structDefId, id -> getBlockingStub().getStructDef(id));
+        return structMapper.toVariableValue(value, variableTypeDefs.get(name));
     }
 
     private String extractWfRunId(IdempotentSinkRecord sinkRecord) {

--- a/connector/src/main/java/io/littlehorse/connect/util/ObjectMapper.java
+++ b/connector/src/main/java/io/littlehorse/connect/util/ObjectMapper.java
@@ -9,10 +9,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ObjectMapper {
-    private ObjectMapper() {}
 
     @SuppressWarnings("unchecked")
-    public static Object removeStruct(Object value) {
+    public Object removeStruct(Object value) {
         if (value instanceof Struct objectStruct) {
             Map<String, Object> result = new HashMap<>();
 
@@ -25,7 +24,7 @@ public class ObjectMapper {
 
         if (value instanceof List) {
             List<Object> objectList = (List<Object>) value;
-            return objectList.stream().map(ObjectMapper::removeStruct).collect(Collectors.toList());
+            return objectList.stream().map(this::removeStruct).collect(Collectors.toList());
         }
 
         if (value instanceof Map) {

--- a/connector/src/main/java/io/littlehorse/connect/util/StructValueMapper.java
+++ b/connector/src/main/java/io/littlehorse/connect/util/StructValueMapper.java
@@ -1,0 +1,78 @@
+package io.littlehorse.connect.util;
+
+import io.littlehorse.sdk.common.LHLibUtil;
+import io.littlehorse.sdk.common.proto.InlineStruct;
+import io.littlehorse.sdk.common.proto.InlineStructDef;
+import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
+import io.littlehorse.sdk.common.proto.StructDef;
+import io.littlehorse.sdk.common.proto.StructDefId;
+import io.littlehorse.sdk.common.proto.StructField;
+import io.littlehorse.sdk.common.proto.StructFieldDef;
+import io.littlehorse.sdk.common.proto.TypeDefinition;
+import io.littlehorse.sdk.common.proto.VariableValue;
+
+import org.apache.kafka.connect.errors.DataException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Builds {@link VariableValue}s from deserialized Kafka record values, resolving LittleHorse
+ * {@code STRUCT} types against their {@link StructDef}s. Each {@link StructDef} is fetched lazily
+ * and cached, so a given definition is only loaded once per task.
+ */
+public class StructValueMapper {
+    private final LittleHorseBlockingStub blockingStub;
+    private final Map<StructDefId, StructDef> structDefCache = new HashMap<>();
+
+    public StructValueMapper(LittleHorseBlockingStub blockingStub) {
+        this.blockingStub = blockingStub;
+    }
+
+    /**
+     * Converts a value into a {@link VariableValue} according to its expected type. When the type
+     * is backed by a {@link StructDefId}, the value is expected to be a key-value pair data set and
+     * is mapped recursively; otherwise it is converted as a regular value.
+     */
+    public VariableValue toVariableValue(Object value, TypeDefinition typeDef) {
+        if (typeDef != null && typeDef.hasStructDefId()) {
+            return buildStructValue(value, typeDef.getStructDefId());
+        }
+        return LHLibUtil.objToVarVal(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private VariableValue buildStructValue(Object value, StructDefId structDefId) {
+        if (value == null) {
+            return VariableValue.newBuilder().build();
+        }
+
+        if (!(value instanceof Map)) {
+            throw new DataException("Expected schema structure not provided, struct variable '"
+                    + structDefId.getName() + "' should be a key-value pair data set");
+        }
+
+        Map<String, Object> fields = (Map<String, Object>) value;
+        InlineStructDef structDef = getStructDef(structDefId).getStructDef();
+        InlineStruct.Builder inlineStruct = InlineStruct.newBuilder();
+
+        for (Map.Entry<String, StructFieldDef> field : structDef.getFieldsMap().entrySet()) {
+            String fieldName = field.getKey();
+            TypeDefinition fieldType = field.getValue().getFieldType();
+            Object fieldValue = fields.get(fieldName);
+
+            VariableValue fieldVarVal = fieldType.hasStructDefId()
+                    ? buildStructValue(fieldValue, fieldType.getStructDefId())
+                    : LHLibUtil.objToVarVal(fieldValue);
+
+            inlineStruct.putFields(
+                    fieldName, StructField.newBuilder().setValue(fieldVarVal).build());
+        }
+
+        return LHLibUtil.inlineStructToVarVal(inlineStruct.build(), structDefId);
+    }
+
+    private StructDef getStructDef(StructDefId structDefId) {
+        return structDefCache.computeIfAbsent(structDefId, blockingStub::getStructDef);
+    }
+}

--- a/connector/src/main/java/io/littlehorse/connect/util/VariableValueMapper.java
+++ b/connector/src/main/java/io/littlehorse/connect/util/VariableValueMapper.java
@@ -21,11 +21,11 @@ import java.util.Map;
  * {@code STRUCT} types against their {@link StructDef}s. Each {@link StructDef} is fetched lazily
  * and cached, so a given definition is only loaded once per task.
  */
-public class StructValueMapper {
+public class VariableValueMapper {
     private final LittleHorseBlockingStub blockingStub;
     private final Map<StructDefId, StructDef> structDefCache = new HashMap<>();
 
-    public StructValueMapper(LittleHorseBlockingStub blockingStub) {
+    public VariableValueMapper(LittleHorseBlockingStub blockingStub) {
         this.blockingStub = blockingStub;
     }
 

--- a/connector/src/test/java/e2e/configs/E2ETest.java
+++ b/connector/src/test/java/e2e/configs/E2ETest.java
@@ -2,6 +2,7 @@ package e2e.configs;
 
 import io.littlehorse.container.LittleHorseContainer;
 import io.littlehorse.sdk.common.config.LHConfig;
+import io.littlehorse.sdk.common.proto.StructDefCompatibilityType;
 import io.littlehorse.sdk.wfsdk.Workflow;
 import io.littlehorse.sdk.worker.LHTaskMethod;
 import io.littlehorse.sdk.worker.LHTaskWorker;
@@ -146,6 +147,24 @@ public abstract class E2ETest {
                         worker.start();
                     });
                 });
+    }
+
+    public void registerStructDef(Object executable, Class<?>... structClasses) {
+        LHTaskWorker worker = Arrays.stream(executable.getClass().getMethods())
+                .filter(method -> method.isAnnotationPresent(LHTaskMethod.class))
+                .map(method -> new LHTaskWorker(
+                        executable,
+                        method.getAnnotation(LHTaskMethod.class).value(),
+                        getLittleHorseConfig()))
+                .findFirst()
+                .orElseThrow(
+                        () -> new IllegalArgumentException("No @LHTaskMethod found on executable"));
+
+        await(() -> {
+            for (Class<?> structClass : structClasses) {
+                worker.registerStructDef(structClass, StructDefCompatibilityType.NO_SCHEMA_UPDATES);
+            }
+        });
     }
 
     public Map<String, Object> getKafkaConfig() {

--- a/connector/src/test/java/e2e/configs/E2ETest.java
+++ b/connector/src/test/java/e2e/configs/E2ETest.java
@@ -13,12 +13,17 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
@@ -29,10 +34,12 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -254,5 +261,25 @@ public abstract class E2ETest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public List<ConsumerRecord<byte[], byte[]>> consumeRecords(String topic, Duration timeout) {
+        Map<String, Object> consumerConfig = new HashMap<>(getKafkaConfig());
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+        consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        consumerConfig.put(
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        consumerConfig.put(
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+
+        List<ConsumerRecord<byte[], byte[]>> records = new ArrayList<>();
+        try (Consumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerConfig)) {
+            consumer.subscribe(List.of(topic));
+            long deadline = System.currentTimeMillis() + timeout.toMillis();
+            while (System.currentTimeMillis() < deadline) {
+                consumer.poll(Duration.ofMillis(500)).forEach(records::add);
+            }
+        }
+        return records;
     }
 }

--- a/connector/src/test/java/e2e/tests/CorrelatedEventsStructParameterTest.java
+++ b/connector/src/test/java/e2e/tests/CorrelatedEventsStructParameterTest.java
@@ -1,0 +1,143 @@
+package e2e.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import e2e.configs.E2ETest;
+
+import io.littlehorse.sdk.common.LHLibUtil;
+import io.littlehorse.sdk.common.proto.LHStatus;
+import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
+import io.littlehorse.sdk.common.proto.RunWfRequest;
+import io.littlehorse.sdk.common.proto.WfRun;
+import io.littlehorse.sdk.wfsdk.Workflow;
+import io.littlehorse.sdk.worker.LHStructDef;
+import io.littlehorse.sdk.worker.LHTaskMethod;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+public class CorrelatedEventsStructParameterTest extends E2ETest {
+
+    public static final String WORKFLOW_NAME = "correlated-events-struct";
+    public static final String TASK_NAME = "correlated-events-struct";
+    public static final String EXTERNAL_EVENT = "correlated-events-struct";
+    public static final String CONNECTOR_NAME = "correlated-events-struct";
+    public static final String VAR_ID = "id";
+    private static final String TOPIC_NAME = "correlated-events-struct";
+    private static final Workflow WORKFLOW = Workflow.newWorkflow(
+            WORKFLOW_NAME,
+            wf -> wf.execute(
+                    TASK_NAME,
+                    wf.waitForEvent(EXTERNAL_EVENT)
+                            .withCorrelationId(wf.declareStr(VAR_ID))
+                            .registeredAs(Pilot.class)));
+    private final LittleHorseBlockingStub lhClient = getLittleHorseConfig().getBlockingStub();
+
+    @LHStructDef("correlated-events-struct-vehicle")
+    public static class Vehicle {
+
+        private String model;
+
+        public Vehicle() {}
+
+        public Vehicle(String model) {
+            this.model = model;
+        }
+
+        public String getModel() {
+            return model;
+        }
+
+        public void setModel(String model) {
+            this.model = model;
+        }
+    }
+
+    @LHStructDef("correlated-events-struct-pilot")
+    public static class Pilot {
+
+        private String name;
+        private Vehicle vehicle;
+
+        public Pilot() {}
+
+        public Pilot(String name, Vehicle vehicle) {
+            this.name = name;
+            this.vehicle = vehicle;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Vehicle getVehicle() {
+            return vehicle;
+        }
+
+        public void setVehicle(Vehicle vehicle) {
+            this.vehicle = vehicle;
+        }
+    }
+
+    @LHTaskMethod(TASK_NAME)
+    public String greeting(Pilot pilot) {
+        String message = String.format(
+                "Hello %s, you're driving a %s!",
+                pilot.getName(), pilot.getVehicle().getModel());
+        log.info("Executing worker, output: {}", message);
+        return message;
+    }
+
+    @Test
+    public void shouldSendStructCorrelatedEventsAfterProducing() {
+        String wfRunId = UUID.randomUUID().toString();
+        String correlatedId = "MyUniqueID." + UUID.randomUUID();
+
+        registerStructDef(this, Vehicle.class, Pilot.class);
+        startWorker(this);
+        registerWorkflow(WORKFLOW);
+        createTopics(TOPIC_NAME);
+        produceValues(
+                TOPIC_NAME,
+                KafkaMessage.of(
+                        correlatedId, getJsonStr(new Pilot("Luke", new Vehicle("X-wing")))));
+        registerConnector(CONNECTOR_NAME, getConnectorConfig());
+
+        lhClient.runWf(RunWfRequest.newBuilder()
+                .setId(wfRunId)
+                .setWfSpecName(WORKFLOW_NAME)
+                .putVariables(VAR_ID, LHLibUtil.objToVarVal(correlatedId))
+                .build());
+
+        await(() -> {
+            WfRun wfRun = lhClient.getWfRun(LHLibUtil.wfRunIdFromString(wfRunId));
+            assertThat(wfRun.getStatus()).isEqualTo(LHStatus.COMPLETED);
+        });
+    }
+
+    private String getJsonStr(Object object) {
+        return LHLibUtil.serializeToJson(object).getJsonStr();
+    }
+
+    private static HashMap<String, Object> getConnectorConfig() {
+        HashMap<String, Object> connectorConfig = new HashMap<>();
+        connectorConfig.put("tasks.max", 1);
+        connectorConfig.put(
+                "connector.class", "io.littlehorse.connect.CorrelatedEventSinkConnector");
+        connectorConfig.put("topics", TOPIC_NAME);
+        connectorConfig.put("key.converter", "org.apache.kafka.connect.storage.StringConverter");
+        connectorConfig.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
+        connectorConfig.put("value.converter.schemas.enable", false);
+        connectorConfig.put("lhc.api.port", 2023);
+        connectorConfig.put("lhc.api.host", "littlehorse");
+        connectorConfig.put("lhc.tenant.id", "default");
+        connectorConfig.put("external.event.name", EXTERNAL_EVENT);
+        return connectorConfig;
+    }
+}

--- a/connector/src/test/java/e2e/tests/ExternalEventsStructParameterTest.java
+++ b/connector/src/test/java/e2e/tests/ExternalEventsStructParameterTest.java
@@ -1,0 +1,134 @@
+package e2e.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import e2e.configs.E2ETest;
+
+import io.littlehorse.sdk.common.LHLibUtil;
+import io.littlehorse.sdk.common.proto.LHStatus;
+import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
+import io.littlehorse.sdk.common.proto.RunWfRequest;
+import io.littlehorse.sdk.common.proto.WfRun;
+import io.littlehorse.sdk.wfsdk.Workflow;
+import io.littlehorse.sdk.worker.LHStructDef;
+import io.littlehorse.sdk.worker.LHTaskMethod;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+public class ExternalEventsStructParameterTest extends E2ETest {
+
+    public static final String WORKFLOW_NAME = "external-events-struct";
+    public static final String TASK_NAME = "external-events-struct";
+    public static final String EXTERNAL_EVENT = "external-events-struct";
+    public static final String CONNECTOR_NAME = "external-events-struct";
+    private static final String TOPIC_NAME = "external-events-struct";
+    private static final Workflow WORKFLOW = Workflow.newWorkflow(
+            WORKFLOW_NAME,
+            wf -> wf.execute(TASK_NAME, wf.waitForEvent(EXTERNAL_EVENT).registeredAs(Pilot.class)));
+    private final LittleHorseBlockingStub lhClient = getLittleHorseConfig().getBlockingStub();
+
+    @LHStructDef("external-events-struct-vehicle")
+    public static class Vehicle {
+
+        private String model;
+
+        public Vehicle() {}
+
+        public Vehicle(String model) {
+            this.model = model;
+        }
+
+        public String getModel() {
+            return model;
+        }
+
+        public void setModel(String model) {
+            this.model = model;
+        }
+    }
+
+    @LHStructDef("external-events-struct-pilot")
+    public static class Pilot {
+
+        private String name;
+        private Vehicle vehicle;
+
+        public Pilot() {}
+
+        public Pilot(String name, Vehicle vehicle) {
+            this.name = name;
+            this.vehicle = vehicle;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Vehicle getVehicle() {
+            return vehicle;
+        }
+
+        public void setVehicle(Vehicle vehicle) {
+            this.vehicle = vehicle;
+        }
+    }
+
+    @LHTaskMethod(TASK_NAME)
+    public String greeting(Pilot pilot) {
+        String message = String.format(
+                "Hello %s, you're driving a %s!",
+                pilot.getName(), pilot.getVehicle().getModel());
+        log.info("Executing worker, output: {}", message);
+        return message;
+    }
+
+    @Test
+    public void shouldSendStructExternalEventsAfterProducing() {
+        String wfRunId = UUID.randomUUID().toString();
+
+        registerStructDef(this, Vehicle.class, Pilot.class);
+        startWorker(this);
+        registerWorkflow(WORKFLOW);
+        createTopics(TOPIC_NAME);
+        produceValues(
+                TOPIC_NAME,
+                KafkaMessage.of(wfRunId, getJsonStr(new Pilot("Luke", new Vehicle("X-wing")))));
+        registerConnector(CONNECTOR_NAME, getConnectorConfig());
+
+        lhClient.runWf(RunWfRequest.newBuilder()
+                .setId(wfRunId)
+                .setWfSpecName(WORKFLOW_NAME)
+                .build());
+
+        await(() -> {
+            WfRun wfRun = lhClient.getWfRun(LHLibUtil.wfRunIdFromString(wfRunId));
+            assertThat(wfRun.getStatus()).isEqualTo(LHStatus.COMPLETED);
+        });
+    }
+
+    private String getJsonStr(Object object) {
+        return LHLibUtil.serializeToJson(object).getJsonStr();
+    }
+
+    private static HashMap<String, Object> getConnectorConfig() {
+        HashMap<String, Object> connectorConfig = new HashMap<>();
+        connectorConfig.put("tasks.max", 1);
+        connectorConfig.put("connector.class", "io.littlehorse.connect.ExternalEventSinkConnector");
+        connectorConfig.put("topics", TOPIC_NAME);
+        connectorConfig.put("key.converter", "org.apache.kafka.connect.storage.StringConverter");
+        connectorConfig.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
+        connectorConfig.put("value.converter.schemas.enable", false);
+        connectorConfig.put("lhc.api.port", 2023);
+        connectorConfig.put("lhc.api.host", "littlehorse");
+        connectorConfig.put("lhc.tenant.id", "default");
+        connectorConfig.put("external.event.name", EXTERNAL_EVENT);
+        return connectorConfig;
+    }
+}

--- a/connector/src/test/java/e2e/tests/RunWorkflowsStructParameterTest.java
+++ b/connector/src/test/java/e2e/tests/RunWorkflowsStructParameterTest.java
@@ -1,0 +1,171 @@
+package e2e.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import e2e.configs.E2ETest;
+
+import io.littlehorse.sdk.common.LHLibUtil;
+import io.littlehorse.sdk.common.proto.LHStatus;
+import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
+import io.littlehorse.sdk.common.proto.SearchTaskRunRequest;
+import io.littlehorse.sdk.common.proto.SearchWfRunRequest;
+import io.littlehorse.sdk.common.proto.TaskRunIdList;
+import io.littlehorse.sdk.common.proto.WfRunId;
+import io.littlehorse.sdk.common.proto.WfRunIdList;
+import io.littlehorse.sdk.wfsdk.Workflow;
+import io.littlehorse.sdk.worker.LHStructDef;
+import io.littlehorse.sdk.worker.LHTaskMethod;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+public class RunWorkflowsStructParameterTest extends E2ETest {
+
+    public static final String WORKFLOW_NAME = "struct-workflow";
+    public static final String TASK_NAME = "struct-workflow";
+    public static final String CONNECTOR_NAME = "struct-workflow";
+    private static final String INPUT_PARAMETER = "pilot";
+    private static final String INPUT_TOPIC = "pilot";
+    private static final Workflow WORKFLOW = Workflow.newWorkflow(
+            WORKFLOW_NAME,
+            wf -> wf.execute(TASK_NAME, wf.declareStruct(INPUT_PARAMETER, Pilot.class)));
+    private final LittleHorseBlockingStub lhClient = getLittleHorseConfig().getBlockingStub();
+
+    @LHStructDef("struct-workflow-vehicle")
+    public static class Vehicle {
+
+        private String model;
+
+        public Vehicle() {}
+
+        public Vehicle(String model) {
+            this.model = model;
+        }
+
+        public String getModel() {
+            return model;
+        }
+
+        public void setModel(String model) {
+            this.model = model;
+        }
+    }
+
+    @LHStructDef("struct-workflow-pilot")
+    public static class Pilot {
+
+        private String name;
+        private Vehicle vehicle;
+
+        public Pilot() {}
+
+        public Pilot(String name, Vehicle vehicle) {
+            this.name = name;
+            this.vehicle = vehicle;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Vehicle getVehicle() {
+            return vehicle;
+        }
+
+        public void setVehicle(Vehicle vehicle) {
+            this.vehicle = vehicle;
+        }
+    }
+
+    public static class StructInput {
+
+        private Pilot pilot;
+
+        public StructInput() {}
+
+        public StructInput(Pilot pilot) {
+            this.pilot = pilot;
+        }
+
+        public Pilot getPilot() {
+            return pilot;
+        }
+
+        public void setPilot(Pilot pilot) {
+            this.pilot = pilot;
+        }
+    }
+
+    @LHTaskMethod(TASK_NAME)
+    public String structWorkflow(Pilot pilot) {
+        String message = String.format(
+                "Hello %s, you're driving a %s!",
+                pilot.getName(), pilot.getVehicle().getModel());
+        log.info("Executing worker, output: {}", message);
+        return message;
+    }
+
+    @Test
+    public void shouldExecuteWfRunAfterProducing() {
+        registerStructDef(this, Vehicle.class, Pilot.class);
+        startWorker(this);
+        registerWorkflow(WORKFLOW);
+        createTopics(INPUT_TOPIC);
+        produceValues(
+                INPUT_TOPIC,
+                KafkaMessage.of(
+                        getJsonStr(new StructInput(new Pilot("Luke", new Vehicle("X-wing"))))),
+                KafkaMessage.of(
+                        getJsonStr(new StructInput(new Pilot("Leia", new Vehicle("Tantive IV"))))));
+        registerConnector(CONNECTOR_NAME, getConnectorConfig());
+
+        await(() -> {
+            SearchWfRunRequest criteria = SearchWfRunRequest.newBuilder()
+                    .setStatus(LHStatus.COMPLETED)
+                    .setWfSpecName(WORKFLOW_NAME)
+                    .build();
+            WfRunIdList result = lhClient.searchWfRun(criteria);
+
+            WfRunIdList expected = WfRunIdList.newBuilder()
+                    .addResults(WfRunId.newBuilder()
+                            .setId("%s-%s-0-0".formatted(CONNECTOR_NAME, INPUT_TOPIC))
+                            .build())
+                    .addResults(WfRunId.newBuilder()
+                            .setId("%s-%s-0-1".formatted(CONNECTOR_NAME, INPUT_TOPIC))
+                            .build())
+                    .build();
+            assertThat(result).isEqualTo(expected);
+        });
+
+        await(() -> {
+            SearchTaskRunRequest criteria =
+                    SearchTaskRunRequest.newBuilder().setTaskDefName(TASK_NAME).build();
+            TaskRunIdList result = lhClient.searchTaskRun(criteria);
+            assertThat(result.getResultsCount()).isEqualTo(2);
+        });
+    }
+
+    private String getJsonStr(Object object) {
+        return LHLibUtil.serializeToJson(object).getJsonStr();
+    }
+
+    private static HashMap<String, Object> getConnectorConfig() {
+        HashMap<String, Object> connectorConfig = new HashMap<>();
+        connectorConfig.put("tasks.max", 1);
+        connectorConfig.put("connector.class", "io.littlehorse.connect.WfRunSinkConnector");
+        connectorConfig.put("topics", INPUT_TOPIC);
+        connectorConfig.put("key.converter", "org.apache.kafka.connect.storage.StringConverter");
+        connectorConfig.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
+        connectorConfig.put("value.converter.schemas.enable", false);
+        connectorConfig.put("lhc.api.port", 2023);
+        connectorConfig.put("lhc.api.host", "littlehorse");
+        connectorConfig.put("lhc.tenant.id", "default");
+        connectorConfig.put("wf.spec.name", WORKFLOW_NAME);
+        return connectorConfig;
+    }
+}

--- a/connector/src/test/java/e2e/tests/WfRunDlqTest.java
+++ b/connector/src/test/java/e2e/tests/WfRunDlqTest.java
@@ -1,0 +1,108 @@
+package e2e.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import e2e.configs.E2ETest;
+
+import io.littlehorse.sdk.common.LHLibUtil;
+import io.littlehorse.sdk.common.proto.LHStatus;
+import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
+import io.littlehorse.sdk.common.proto.WfRun;
+import io.littlehorse.sdk.wfsdk.Workflow;
+import io.littlehorse.sdk.worker.LHTaskMethod;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+
+public class WfRunDlqTest extends E2ETest {
+
+    public static final String WORKFLOW_NAME = "wfrun-dlq";
+    public static final String TASK_NAME = "wfrun-dlq";
+    public static final String CONNECTOR_NAME = "wfrun-dlq";
+    private static final String INPUT_PARAMETER = "name";
+    private static final String INPUT_TOPIC = "wfrun-dlq";
+    private static final String DLQ_TOPIC = "wfrun-dlq-errors";
+    private static final Workflow WORKFLOW = Workflow.newWorkflow(
+            WORKFLOW_NAME, wf -> wf.execute(TASK_NAME, wf.declareStr(INPUT_PARAMETER)));
+    private final LittleHorseBlockingStub lhClient = getLittleHorseConfig().getBlockingStub();
+
+    @LHTaskMethod(TASK_NAME)
+    public String greet(String name) {
+        String message = String.format("Hello %s!", name);
+        log.info("Executing worker, output: {}", message);
+        return message;
+    }
+
+    @Test
+    public void shouldRouteBadRecordToDlqAndKeepProcessing() {
+        startWorker(this);
+        registerWorkflow(WORKFLOW);
+        createTopics(INPUT_TOPIC, DLQ_TOPIC);
+        // offset 0 is a permanent error (not a key-value pair); offset 1 is a valid record.
+        // With errors.tolerance=all the bad record must be routed to the DLQ without blocking
+        // the valid record that follows it.
+        produceValues(
+                INPUT_TOPIC,
+                KafkaMessage.of("42"),
+                KafkaMessage.of(getJsonStr(new NameInput("Luke"))));
+        registerConnector(CONNECTOR_NAME, getConnectorConfig());
+
+        await(() -> {
+            WfRun wfRun = lhClient.getWfRun(LHLibUtil.wfRunIdFromString(
+                    "%s-%s-0-1".formatted(CONNECTOR_NAME, INPUT_TOPIC)));
+            assertThat(wfRun.getStatus()).isEqualTo(LHStatus.COMPLETED);
+        });
+
+        await(() -> {
+            List<ConsumerRecord<byte[], byte[]>> dlqRecords =
+                    consumeRecords(DLQ_TOPIC, Duration.ofSeconds(1));
+            assertThat(dlqRecords).isNotEmpty();
+        });
+    }
+
+    private String getJsonStr(Object object) {
+        return LHLibUtil.serializeToJson(object).getJsonStr();
+    }
+
+    public static class NameInput {
+
+        private String name;
+
+        public NameInput() {}
+
+        public NameInput(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    private static HashMap<String, Object> getConnectorConfig() {
+        HashMap<String, Object> connectorConfig = new HashMap<>();
+        connectorConfig.put("tasks.max", 1);
+        connectorConfig.put("connector.class", "io.littlehorse.connect.WfRunSinkConnector");
+        connectorConfig.put("topics", INPUT_TOPIC);
+        connectorConfig.put("key.converter", "org.apache.kafka.connect.storage.StringConverter");
+        connectorConfig.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
+        connectorConfig.put("value.converter.schemas.enable", false);
+        connectorConfig.put("errors.tolerance", "all");
+        connectorConfig.put("errors.deadletterqueue.topic.name", DLQ_TOPIC);
+        connectorConfig.put("errors.deadletterqueue.topic.replication.factor", 1);
+        connectorConfig.put("errors.deadletterqueue.context.headers.enable", true);
+        connectorConfig.put("lhc.api.port", 2023);
+        connectorConfig.put("lhc.api.host", "littlehorse");
+        connectorConfig.put("lhc.tenant.id", "default");
+        connectorConfig.put("wf.spec.name", WORKFLOW_NAME);
+        return connectorConfig;
+    }
+}

--- a/connector/src/test/java/io/littlehorse/connect/util/ObjectMapperTest.java
+++ b/connector/src/test/java/io/littlehorse/connect/util/ObjectMapperTest.java
@@ -16,6 +16,8 @@ import java.util.Map;
 
 class ObjectMapperTest {
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     @Test
     void shouldAllowNullInStruct() {
         String expectedFieldName = "my-null-input";
@@ -30,20 +32,20 @@ class ObjectMapperTest {
         Map<String, Object> expected = new HashMap<>();
         expected.put(expectedFieldName, null);
 
-        assertThat(ObjectMapper.removeStruct(input)).isEqualTo(expected);
+        assertThat(objectMapper.removeStruct(input)).isEqualTo(expected);
     }
 
     @Test
     void shouldAllowNullInLists() {
         List<Object> input = new ArrayList<>();
         input.add(null);
-        assertThat(ObjectMapper.removeStruct(input)).isEqualTo(input);
+        assertThat(objectMapper.removeStruct(input)).isEqualTo(input);
     }
 
     @Test
     void shouldAllowNullInMaps() {
         Map<String, Object> input = new HashMap<>();
         input.put("my-null-input", null);
-        assertThat(ObjectMapper.removeStruct(input)).isEqualTo(input);
+        assertThat(objectMapper.removeStruct(input)).isEqualTo(input);
     }
 }

--- a/connector/src/test/java/io/littlehorse/connect/util/VariableValueMapperTest.java
+++ b/connector/src/test/java/io/littlehorse/connect/util/VariableValueMapperTest.java
@@ -1,0 +1,151 @@
+package io.littlehorse.connect.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.littlehorse.sdk.common.LHLibUtil;
+import io.littlehorse.sdk.common.proto.InlineStruct;
+import io.littlehorse.sdk.common.proto.InlineStructDef;
+import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
+import io.littlehorse.sdk.common.proto.StructDef;
+import io.littlehorse.sdk.common.proto.StructDefId;
+import io.littlehorse.sdk.common.proto.StructField;
+import io.littlehorse.sdk.common.proto.StructFieldDef;
+import io.littlehorse.sdk.common.proto.TypeDefinition;
+import io.littlehorse.sdk.common.proto.VariableValue;
+
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+class VariableValueMapperTest {
+
+    private static final StructDefId PILOT_ID =
+            StructDefId.newBuilder().setName("pilot").setVersion(0).build();
+    private static final StructDefId VEHICLE_ID =
+            StructDefId.newBuilder().setName("vehicle").setVersion(0).build();
+
+    private final LittleHorseBlockingStub blockingStub = mock(LittleHorseBlockingStub.class);
+    private final VariableValueMapper mapper = new VariableValueMapper(blockingStub);
+
+    @Test
+    void shouldConvertRegularValueWhenTypeDefIsNull() {
+        VariableValue result = mapper.toVariableValue("Luke", null);
+
+        assertThat(result).isEqualTo(LHLibUtil.objToVarVal("Luke"));
+        verifyNoInteractions(blockingStub);
+    }
+
+    @Test
+    void shouldConvertRegularValueWhenTypeDefIsNotStruct() {
+        TypeDefinition strType = TypeDefinition.newBuilder().build();
+
+        VariableValue result = mapper.toVariableValue("Luke", strType);
+
+        assertThat(result).isEqualTo(LHLibUtil.objToVarVal("Luke"));
+        verifyNoInteractions(blockingStub);
+    }
+
+    @Test
+    void shouldBuildStructValue() {
+        when(blockingStub.getStructDef(PILOT_ID))
+                .thenReturn(structDef(InlineStructDef.newBuilder()
+                        .putFields("name", primitiveField())
+                        .build()));
+
+        VariableValue result = mapper.toVariableValue(Map.of("name", "Luke"), structType(PILOT_ID));
+
+        VariableValue expected = LHLibUtil.inlineStructToVarVal(
+                InlineStruct.newBuilder()
+                        .putFields("name", structField(LHLibUtil.objToVarVal("Luke")))
+                        .build(),
+                PILOT_ID);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldBuildNestedStructValue() {
+        when(blockingStub.getStructDef(PILOT_ID))
+                .thenReturn(structDef(InlineStructDef.newBuilder()
+                        .putFields("name", primitiveField())
+                        .putFields("vehicle", structFieldDef(VEHICLE_ID))
+                        .build()));
+        when(blockingStub.getStructDef(VEHICLE_ID))
+                .thenReturn(structDef(InlineStructDef.newBuilder()
+                        .putFields("model", primitiveField())
+                        .build()));
+
+        VariableValue result = mapper.toVariableValue(
+                Map.of("name", "Luke", "vehicle", Map.of("model", "X-wing")), structType(PILOT_ID));
+
+        VariableValue expectedVehicle = LHLibUtil.inlineStructToVarVal(
+                InlineStruct.newBuilder()
+                        .putFields("model", structField(LHLibUtil.objToVarVal("X-wing")))
+                        .build(),
+                VEHICLE_ID);
+        VariableValue expected = LHLibUtil.inlineStructToVarVal(
+                InlineStruct.newBuilder()
+                        .putFields("name", structField(LHLibUtil.objToVarVal("Luke")))
+                        .putFields("vehicle", structField(expectedVehicle))
+                        .build(),
+                PILOT_ID);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldFetchEachStructDefOnlyOnce() {
+        when(blockingStub.getStructDef(PILOT_ID))
+                .thenReturn(structDef(InlineStructDef.newBuilder()
+                        .putFields("name", primitiveField())
+                        .build()));
+
+        mapper.toVariableValue(Map.of("name", "Luke"), structType(PILOT_ID));
+        mapper.toVariableValue(Map.of("name", "Leia"), structType(PILOT_ID));
+
+        verify(blockingStub, times(1)).getStructDef(PILOT_ID);
+    }
+
+    @Test
+    void shouldReturnEmptyVariableValueWhenStructValueIsNull() {
+        VariableValue result = mapper.toVariableValue(null, structType(PILOT_ID));
+
+        assertThat(result).isEqualTo(VariableValue.newBuilder().build());
+        verifyNoInteractions(blockingStub);
+    }
+
+    @Test
+    void shouldThrowWhenStructValueIsNotAMap() {
+        assertThatThrownBy(() -> mapper.toVariableValue("not-a-map", structType(PILOT_ID)))
+                .isInstanceOf(DataException.class)
+                .hasMessageContaining("pilot");
+        verifyNoInteractions(blockingStub);
+    }
+
+    private static TypeDefinition structType(StructDefId structDefId) {
+        return TypeDefinition.newBuilder().setStructDefId(structDefId).build();
+    }
+
+    private static StructDef structDef(InlineStructDef inlineStructDef) {
+        return StructDef.newBuilder().setStructDef(inlineStructDef).build();
+    }
+
+    private static StructFieldDef primitiveField() {
+        return StructFieldDef.newBuilder()
+                .setFieldType(TypeDefinition.newBuilder().build())
+                .build();
+    }
+
+    private static StructFieldDef structFieldDef(StructDefId structDefId) {
+        return StructFieldDef.newBuilder().setFieldType(structType(structDefId)).build();
+    }
+
+    private static StructField structField(VariableValue value) {
+        return StructField.newBuilder().setValue(value).build();
+    }
+}

--- a/examples/correlated-event-struct/README.md
+++ b/examples/correlated-event-struct/README.md
@@ -1,0 +1,141 @@
+# CorrelatedEvent Connector with StructDef
+
+In this example you will:
+
+- Define LittleHorse [StructDefs](https://littlehorse.io/docs/server/concepts/structs) (`Pilot` with a nested `Vehicle`).
+- Register a workflow that waits for a correlated event whose content is a `STRUCT`.
+- Produce json messages to a kafka topic without SchemaRegistry.
+- Create a CorrelatedEventSinkConnector without transformations.
+- The CorrelatedEventSinkConnector posts correlated events with struct content.
+
+> [!WARNING]
+> Run the commands in the root directory
+
+> [!NOTE]
+> The connector reads the `ExternalEventDef` on startup to detect that its content is a
+> `STRUCT`, so it builds the LittleHorse struct from the json object automatically.
+> Each record key is the `correlationId` and each record value is the `Pilot` struct.
+
+## Dependencies
+
+- httpie
+- docker
+- java
+
+## Setup Environment
+
+Build plugin bundle:
+
+```shell
+./gradlew buildConfluentBundle
+```
+
+Run environment:
+
+```shell
+docker compose up -d
+```
+
+## Populate Topic
+
+Create topic:
+
+```shell
+docker compose exec kafka-connect \
+kafka-topics --create --bootstrap-server kafka1:9092 \
+--replication-factor 3 \
+--partitions 12 \
+--topic example-correlated-event-struct
+```
+
+Produce:
+
+```shell
+docker compose exec -T kafka-connect \
+kafka-console-producer --bootstrap-server kafka1:9092 \
+--topic example-correlated-event-struct \
+--property "parse.key=true" \
+--property "key.separator=|" \
+< examples/correlated-event-struct/data.txt
+```
+
+Consume:
+
+> [!NOTE]
+> In case you need to verify the messages in the topic.
+
+```shell
+docker compose exec kafka-connect \
+kafka-console-consumer --bootstrap-server kafka1:9092 \
+--topic example-correlated-event-struct \
+--property "print.key=true" \
+--property "key.separator=|" \
+--from-beginning
+```
+
+> [!NOTE]
+> If you need to generate new data run:
+
+```shell
+./gradlew -q example-correlated-event-struct:run -DmainClass="io.littlehorse.example.DataGenerator" --args="10" > examples/correlated-event-struct/data.txt
+```
+
+## Run Worker
+
+Run worker (registers the `Vehicle` and `Pilot` `StructDef`s, the `TaskDef`, and the `WfSpec`):
+
+```shell
+./gradlew example-correlated-event-struct:run
+```
+
+Verify the `StructDef`s were created:
+
+```shell
+lhctl get structDef example-correlated-event-struct-pilot 0
+lhctl get structDef example-correlated-event-struct-vehicle 0
+```
+
+## Create Connector
+
+Create connector:
+
+```shell
+http PUT :8083/connectors/example-correlated-event-struct/config < examples/correlated-event-struct/connector.json
+```
+
+Get connector:
+
+```shell
+http :8083/connectors/example-correlated-event-struct
+```
+
+## Check CorrelatedEvents
+
+List correlated events:
+
+```shell
+lhctl search correlatedEvent example-correlated-event-struct
+```
+
+> At this point all the correlated events are waiting for being claimed.
+
+## Run Workflows
+
+Run workflows with the same id for every correlated event:
+
+```shell
+while read line; do \
+  lhctl run example-correlated-event-struct id "${line%|*}"; \
+done < examples/correlated-event-struct/data.txt
+```
+
+## Check WfRuns
+
+List WfRuns:
+
+```shell
+lhctl search wfRun example-correlated-event-struct
+```
+
+> You can use `lhctl get externalEvent <wfRunId> <externalEventDefName> <guid>` \
+> and `lhctl get wfRun <id>` to inspect the results.

--- a/examples/correlated-event-struct/build.gradle
+++ b/examples/correlated-event-struct/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id "application"
+}
+
+dependencies {
+    // utils
+    implementation "net.datafaker:datafaker:${datafakerVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    implementation project(":common")
+
+    // littlehorse
+    implementation "io.littlehorse:littlehorse-client:${lhVersion}"
+
+    // log
+    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
+    implementation "org.slf4j:slf4j-simple:${slf4jVersion}"
+
+    // lombok
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testImplementation platform("org.junit:junit-bom:${junitVersion}")
+    testImplementation "org.junit.jupiter:junit-jupiter"
+}
+
+test {
+    useJUnitPlatform()
+}
+
+application {
+    mainClass = System.getProperty("mainClass", "io.littlehorse.example.Main")
+}
+
+compileJava {
+    options.compilerArgs << "-parameters"
+}

--- a/examples/correlated-event-struct/connector.json
+++ b/examples/correlated-event-struct/connector.json
@@ -1,0 +1,12 @@
+{
+  "tasks.max": 2,
+  "connector.class": "io.littlehorse.connect.CorrelatedEventSinkConnector",
+  "topics": "example-correlated-event-struct",
+  "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "value.converter.schemas.enable": false,
+  "lhc.api.port": 2024,
+  "lhc.api.host": "littlehorse",
+  "lhc.tenant.id": "default",
+  "external.event.name": "example-correlated-event-struct"
+}

--- a/examples/correlated-event-struct/data.txt
+++ b/examples/correlated-event-struct/data.txt
@@ -1,0 +1,10 @@
+427a63878fae4f91b251040e0449b19a|{"name":"Luke Skywalker","vehicle":{"model":"Snowspeeder"}}
+003246152ac542b5a816d2ea9f304f1d|{"name":"Han Solo","vehicle":{"model":"Millennium Falcon"}}
+39c2fef095874e2b8daa5e40205bc992|{"name":"Anakin Skywalker","vehicle":{"model":"Jedi starfighter"}}
+1e0d9a6f4c7b4e9d8a2f6b3c5d1e7f80|{"name":"Leia Organa","vehicle":{"model":"Speeder bike"}}
+8b4c2d1e6f3a4b7c9d0e1f2a3b4c5d6e|{"name":"Obi-Wan Kenobi","vehicle":{"model":"Jedi starfighter"}}
+2a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d|{"name":"Chewbacca","vehicle":{"model":"Millennium Falcon"}}
+6f5e4d3c2b1a0f9e8d7c6b5a4f3e2d1c|{"name":"Padme Amidala","vehicle":{"model":"Naboo star skiff"}}
+9c8b7a6f5e4d3c2b1a0f9e8d7c6b5a4f|{"name":"Darth Vader","vehicle":{"model":"TIE Advanced x1"}}
+4d3c2b1a0f9e8d7c6b5a4f3e2d1c0b9a|{"name":"Yoda","vehicle":{"model":"Republic Gunship"}}
+7e6d5c4b3a2f1e0d9c8b7a6f5e4d3c2b|{"name":"Lando Calrissian","vehicle":{"model":"Millennium Falcon"}}

--- a/examples/correlated-event-struct/src/main/java/io/littlehorse/example/DataGenerator.java
+++ b/examples/correlated-event-struct/src/main/java/io/littlehorse/example/DataGenerator.java
@@ -1,0 +1,28 @@
+package io.littlehorse.example;
+
+import net.datafaker.Faker;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+public class DataGenerator {
+
+    private static final Faker faker = new Faker();
+
+    public static void main(String[] args) {
+        int datasetSize = args.length > 0 ? Integer.parseInt(args[0]) : 10;
+        Stream.generate(DataGenerator::newRecord).limit(datasetSize).forEach(System.out::println);
+    }
+
+    private static String newKey() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private static String newRecord() {
+        Pilot pilot = Pilot.builder()
+                .name(faker.starWars().character())
+                .vehicle(Vehicle.builder().model(faker.starWars().vehicles()).build())
+                .build();
+        return "%s|%s".formatted(newKey(), pilot);
+    }
+}

--- a/examples/correlated-event-struct/src/main/java/io/littlehorse/example/Main.java
+++ b/examples/correlated-event-struct/src/main/java/io/littlehorse/example/Main.java
@@ -1,0 +1,66 @@
+package io.littlehorse.example;
+
+import static io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
+
+import io.littlehorse.sdk.common.config.LHConfig;
+import io.littlehorse.sdk.common.proto.StructDefCompatibilityType;
+import io.littlehorse.sdk.wfsdk.Workflow;
+import io.littlehorse.sdk.worker.LHTaskMethod;
+import io.littlehorse.sdk.worker.LHTaskWorker;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Main {
+
+    public static final String TASK_DEF_NAME = "example-correlated-event-struct-greet";
+    public static final String WF_NAME = "example-correlated-event-struct";
+    public static final String EXTERNAL_EVENT_NAME = "example-correlated-event-struct";
+    public static final String ID_VARIABLE = "id";
+
+    public static Workflow getWorkflow() {
+        return Workflow.newWorkflow(
+                WF_NAME,
+                wf -> wf.execute(
+                        TASK_DEF_NAME,
+                        wf.waitForEvent(EXTERNAL_EVENT_NAME)
+                                .withCorrelationId(wf.declareStr(ID_VARIABLE))
+                                .registeredAs(Pilot.class)));
+    }
+
+    private static LHTaskWorker getTaskWorker(LHConfig lhConfig) {
+        LHTaskWorker worker = new LHTaskWorker(new GreetingsWorker(), TASK_DEF_NAME, lhConfig);
+        Runtime.getRuntime().addShutdownHook(new Thread(worker::close));
+        return worker;
+    }
+
+    public static void main(String[] args) {
+        LHConfig lhConfig = new LHConfig();
+        LittleHorseBlockingStub stub = lhConfig.getBlockingStub();
+
+        LHTaskWorker worker = getTaskWorker(lhConfig);
+
+        // StructDefs must be registered before the TaskDef and WfSpec that use them.
+        // Dependencies first: Vehicle is nested inside Pilot.
+        worker.registerStructDef(Vehicle.class, StructDefCompatibilityType.NO_SCHEMA_UPDATES);
+        worker.registerStructDef(Pilot.class, StructDefCompatibilityType.NO_SCHEMA_UPDATES);
+
+        worker.registerTaskDef();
+
+        Workflow workflow = getWorkflow();
+        workflow.registerWfSpec(stub);
+
+        worker.start();
+    }
+
+    public static class GreetingsWorker {
+
+        @LHTaskMethod(TASK_DEF_NAME)
+        public String greeting(Pilot pilot) {
+            String message = "Hello there! " + pilot.getName() + ", you're driving a "
+                    + pilot.getVehicle().getModel();
+            log.info(message);
+            return message;
+        }
+    }
+}

--- a/examples/correlated-event-struct/src/main/java/io/littlehorse/example/Pilot.java
+++ b/examples/correlated-event-struct/src/main/java/io/littlehorse/example/Pilot.java
@@ -1,0 +1,26 @@
+package io.littlehorse.example;
+
+import io.littlehorse.sdk.worker.LHStructDef;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@LHStructDef("example-correlated-event-struct-pilot")
+public class Pilot {
+
+    private String name;
+    private Vehicle vehicle;
+
+    @Override
+    public String toString() {
+        return JsonSerializer.serialize(this);
+    }
+}

--- a/examples/correlated-event-struct/src/main/java/io/littlehorse/example/Vehicle.java
+++ b/examples/correlated-event-struct/src/main/java/io/littlehorse/example/Vehicle.java
@@ -1,0 +1,25 @@
+package io.littlehorse.example;
+
+import io.littlehorse.sdk.worker.LHStructDef;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@LHStructDef("example-correlated-event-struct-vehicle")
+public class Vehicle {
+
+    private String model;
+
+    @Override
+    public String toString() {
+        return JsonSerializer.serialize(this);
+    }
+}

--- a/examples/external-event-struct/README.md
+++ b/examples/external-event-struct/README.md
@@ -1,0 +1,141 @@
+# ExternalEvent Connector with StructDef
+
+In this example you will:
+
+- Define LittleHorse [StructDefs](https://littlehorse.io/docs/server/concepts/structs) (`Pilot` with a nested `Vehicle`).
+- Register a workflow that waits for an external event whose content is a `STRUCT`.
+- Produce json messages to a kafka topic without SchemaRegistry.
+- Create an ExternalEventSinkConnector without transformations.
+- The ExternalEventSinkConnector posts external events with struct content.
+
+> [!WARNING]
+> Run the commands in the root directory
+
+> [!NOTE]
+> The connector reads the `ExternalEventDef` on startup to detect that its content is a
+> `STRUCT`, so it builds the LittleHorse struct from the json object automatically.
+> Each record key is the `wfRunId` and each record value is the `Pilot` struct.
+
+## Dependencies
+
+- httpie
+- docker
+- java
+
+## Setup Environment
+
+Build plugin bundle:
+
+```shell
+./gradlew buildConfluentBundle
+```
+
+Run environment:
+
+```shell
+docker compose up -d
+```
+
+## Populate Topic
+
+Create topic:
+
+```shell
+docker compose exec kafka-connect \
+kafka-topics --create --bootstrap-server kafka1:9092 \
+--replication-factor 3 \
+--partitions 12 \
+--topic example-external-event-struct
+```
+
+Produce:
+
+```shell
+docker compose exec -T kafka-connect \
+kafka-console-producer --bootstrap-server kafka1:9092 \
+--topic example-external-event-struct \
+--property "parse.key=true" \
+--property "key.separator=|" \
+< examples/external-event-struct/data.txt
+```
+
+Consume:
+
+> [!NOTE]
+> In case you need to verify the messages in the topic.
+
+```shell
+docker compose exec kafka-connect \
+kafka-console-consumer --bootstrap-server kafka1:9092 \
+--topic example-external-event-struct \
+--property "print.key=true" \
+--property "key.separator=|" \
+--from-beginning
+```
+
+> [!NOTE]
+> If you need to generate new data run:
+
+```shell
+./gradlew -q example-external-event-struct:run -DmainClass="io.littlehorse.example.DataGenerator" --args="10" > examples/external-event-struct/data.txt
+```
+
+## Run Worker
+
+Run worker (registers the `Vehicle` and `Pilot` `StructDef`s, the `TaskDef`, and the `WfSpec`):
+
+```shell
+./gradlew example-external-event-struct:run
+```
+
+Verify the `StructDef`s were created:
+
+```shell
+lhctl get structDef example-external-event-struct-pilot 0
+lhctl get structDef example-external-event-struct-vehicle 0
+```
+
+## Create Connector
+
+Create connector:
+
+```shell
+http PUT :8083/connectors/example-external-event-struct/config < examples/external-event-struct/connector.json
+```
+
+Get connector:
+
+```shell
+http :8083/connectors/example-external-event-struct
+```
+
+## Check ExternalEvents
+
+List external events:
+
+```shell
+lhctl search externalEvent example-external-event-struct
+```
+
+> At this point all the external events are waiting for being claimed.
+
+## Run Workflows
+
+Run workflows with the same id for every external event:
+
+```shell
+while read line; do \
+  lhctl run example-external-event-struct --wfRunId "${line%|*}"; \
+done < examples/external-event-struct/data.txt
+```
+
+## Check WfRuns
+
+List WfRuns:
+
+```shell
+lhctl search wfRun example-external-event-struct
+```
+
+> You can use `lhctl get externalEvent <wfRunId> <externalEventDefName> <guid>` \
+> and `lhctl get wfRun <id>` to inspect the results.

--- a/examples/external-event-struct/build.gradle
+++ b/examples/external-event-struct/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id "application"
+}
+
+dependencies {
+    // utils
+    implementation "net.datafaker:datafaker:${datafakerVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    implementation project(":common")
+
+    // littlehorse
+    implementation "io.littlehorse:littlehorse-client:${lhVersion}"
+
+    // log
+    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
+    implementation "org.slf4j:slf4j-simple:${slf4jVersion}"
+
+    // lombok
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testImplementation platform("org.junit:junit-bom:${junitVersion}")
+    testImplementation "org.junit.jupiter:junit-jupiter"
+}
+
+test {
+    useJUnitPlatform()
+}
+
+application {
+    mainClass = System.getProperty("mainClass", "io.littlehorse.example.Main")
+}
+
+compileJava {
+    options.compilerArgs << "-parameters"
+}

--- a/examples/external-event-struct/connector.json
+++ b/examples/external-event-struct/connector.json
@@ -1,0 +1,12 @@
+{
+  "tasks.max": 2,
+  "connector.class": "io.littlehorse.connect.ExternalEventSinkConnector",
+  "topics": "example-external-event-struct",
+  "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "value.converter.schemas.enable": false,
+  "lhc.api.port": 2024,
+  "lhc.api.host": "littlehorse",
+  "lhc.tenant.id": "default",
+  "external.event.name": "example-external-event-struct"
+}

--- a/examples/external-event-struct/data.txt
+++ b/examples/external-event-struct/data.txt
@@ -1,0 +1,10 @@
+427a63878fae4f91b251040e0449b19a|{"name":"Luke Skywalker","vehicle":{"model":"Snowspeeder"}}
+003246152ac542b5a816d2ea9f304f1d|{"name":"Han Solo","vehicle":{"model":"Millennium Falcon"}}
+39c2fef095874e2b8daa5e40205bc992|{"name":"Anakin Skywalker","vehicle":{"model":"Jedi starfighter"}}
+532c0e6d7e144c479f22e0ddacdc8805|{"name":"Leia Organa","vehicle":{"model":"Tantive IV"}}
+fa4751cfcd1d49bf8fbdaacc4dedb849|{"name":"Padme Amidala","vehicle":{"model":"Naboo Royal Starship"}}
+1ae7e59edb994c498a9439c05fd8d8dd|{"name":"Obi-Wan Kenobi","vehicle":{"model":"Jedi starfighter"}}
+694ed302937a475f9c0c42eac8b6f02e|{"name":"Boba Fett","vehicle":{"model":"Slave I"}}
+547ac029716a401fa69983fba5e7c92f|{"name":"Lando Calrissian","vehicle":{"model":"Millennium Falcon"}}
+bf95d1a8eebd490982ea6bbf8ef1bd72|{"name":"Wedge Antilles","vehicle":{"model":"X-wing"}}
+6a3132c856984460b0431794d5032835|{"name":"Darth Vader","vehicle":{"model":"TIE Advanced x1"}}

--- a/examples/external-event-struct/src/main/java/io/littlehorse/example/DataGenerator.java
+++ b/examples/external-event-struct/src/main/java/io/littlehorse/example/DataGenerator.java
@@ -1,0 +1,28 @@
+package io.littlehorse.example;
+
+import net.datafaker.Faker;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+public class DataGenerator {
+
+    private static final Faker faker = new Faker();
+
+    public static void main(String[] args) {
+        int datasetSize = args.length > 0 ? Integer.parseInt(args[0]) : 10;
+        Stream.generate(DataGenerator::newRecord).limit(datasetSize).forEach(System.out::println);
+    }
+
+    private static String newKey() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private static String newRecord() {
+        Pilot pilot = Pilot.builder()
+                .name(faker.starWars().character())
+                .vehicle(Vehicle.builder().model(faker.starWars().vehicles()).build())
+                .build();
+        return "%s|%s".formatted(newKey(), pilot);
+    }
+}

--- a/examples/external-event-struct/src/main/java/io/littlehorse/example/Main.java
+++ b/examples/external-event-struct/src/main/java/io/littlehorse/example/Main.java
@@ -1,0 +1,60 @@
+package io.littlehorse.example;
+
+import io.littlehorse.sdk.common.config.LHConfig;
+import io.littlehorse.sdk.common.proto.StructDefCompatibilityType;
+import io.littlehorse.sdk.wfsdk.Workflow;
+import io.littlehorse.sdk.worker.LHTaskMethod;
+import io.littlehorse.sdk.worker.LHTaskWorker;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Main {
+
+    public static final String TASK_DEF_NAME = "example-external-event-struct-greet";
+    public static final String WF_NAME = "example-external-event-struct";
+    public static final String EXTERNAL_EVENT_NAME = "example-external-event-struct";
+
+    public static Workflow getWorkflow() {
+        return Workflow.newWorkflow(
+                WF_NAME,
+                wf -> wf.execute(
+                        TASK_DEF_NAME,
+                        wf.waitForEvent(EXTERNAL_EVENT_NAME).registeredAs(Pilot.class)));
+    }
+
+    private static LHTaskWorker getTaskWorker(LHConfig lhConfig) {
+        LHTaskWorker worker = new LHTaskWorker(new GreetingsWorker(), TASK_DEF_NAME, lhConfig);
+        Runtime.getRuntime().addShutdownHook(new Thread(worker::close));
+        return worker;
+    }
+
+    public static void main(String[] args) {
+        LHConfig lhConfig = new LHConfig();
+
+        LHTaskWorker worker = getTaskWorker(lhConfig);
+
+        // StructDefs must be registered before the TaskDef and WfSpec that use them.
+        // Dependencies first: Vehicle is nested inside Pilot.
+        worker.registerStructDef(Vehicle.class, StructDefCompatibilityType.NO_SCHEMA_UPDATES);
+        worker.registerStructDef(Pilot.class, StructDefCompatibilityType.NO_SCHEMA_UPDATES);
+
+        worker.registerTaskDef();
+
+        Workflow workflow = getWorkflow();
+        workflow.registerWfSpec(lhConfig.getBlockingStub());
+
+        worker.start();
+    }
+
+    public static class GreetingsWorker {
+
+        @LHTaskMethod(TASK_DEF_NAME)
+        public String greeting(Pilot pilot) {
+            String message = "Hello there! " + pilot.getName() + ", you're driving a "
+                    + pilot.getVehicle().getModel();
+            log.info(message);
+            return message;
+        }
+    }
+}

--- a/examples/external-event-struct/src/main/java/io/littlehorse/example/Pilot.java
+++ b/examples/external-event-struct/src/main/java/io/littlehorse/example/Pilot.java
@@ -1,0 +1,26 @@
+package io.littlehorse.example;
+
+import io.littlehorse.sdk.worker.LHStructDef;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@LHStructDef("example-external-event-struct-pilot")
+public class Pilot {
+
+    private String name;
+    private Vehicle vehicle;
+
+    @Override
+    public String toString() {
+        return JsonSerializer.serialize(this);
+    }
+}

--- a/examples/external-event-struct/src/main/java/io/littlehorse/example/Vehicle.java
+++ b/examples/external-event-struct/src/main/java/io/littlehorse/example/Vehicle.java
@@ -1,0 +1,25 @@
+package io.littlehorse.example;
+
+import io.littlehorse.sdk.worker.LHStructDef;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@LHStructDef("example-external-event-struct-vehicle")
+public class Vehicle {
+
+    private String model;
+
+    @Override
+    public String toString() {
+        return JsonSerializer.serialize(this);
+    }
+}

--- a/examples/wfrun-dlq/README.md
+++ b/examples/wfrun-dlq/README.md
@@ -5,7 +5,13 @@ In this example you will:
 - Register a workflow with variable types: `STR`.
 - Produce json messages to a kafka topic without SchemaRegistry.
 - Create a WfRunSinkConnector with DLQ and without transformations.
-- Introduce errors, this error will be redirected to a DLQ topic.
+- Introduce a permanent error, this error will be redirected to a DLQ topic.
+
+> [!NOTE]
+> Only permanent errors (such as the invalid records in this example) are sent
+> to the DLQ. Transient errors, like network issues or LittleHorse being
+> temporarily unavailable, are retried instead. See the
+> [Error Handling](../../README.md#error-handling) section for details.
 
 > [!WARNING]
 > Run the commands in the root directory

--- a/examples/wfrun-struct/README.md
+++ b/examples/wfrun-struct/README.md
@@ -5,18 +5,20 @@ In this example you will:
 - Define LittleHorse [StructDefs](https://littlehorse.io/docs/server/concepts/structs) (`Pilot` with a nested `Vehicle`).
 - Register a workflow with a `STRUCT` variable type.
 - Produce json messages to a kafka topic without SchemaRegistry.
-- Create a WfRunSinkConnector without transformations.
+- Create a WfRunSinkConnector with a `HoistField` transformation.
 
 > [!WARNING]
 > Run the commands in the root directory
 
-> [!IMPORTANT]
-> `StructDef`s are experimental in LittleHorse and **not yet supported by the Kafka
-> Connect sink connectors**. This example shows how to model and register the
-> `StructDef`s and a workflow that uses them. The connector configuration is included
-> for completeness, but passing a `Struct` as a `WfRun` variable through Kafka Connect
-> is not wired up yet. See the upstream
+> [!NOTE]
+> The connector reads the `WfSpec` on startup to detect that the `pilot` variable is a
+> `STRUCT`, so it builds the LittleHorse struct from the nested json object automatically.
+> The `data.txt` records hold the struct fields at the top level (`{"name":...,"vehicle":...}`),
+> so the `connector.json` uses a [`HoistField`](https://docs.confluent.io/kafka-connectors/transforms/current/hoistfield.html)
+> transformation to wrap each record under the `pilot` field before it reaches LittleHorse.
+> See the upstream
 > [struct-def example](https://github.com/littlehorse-enterprises/littlehorse/tree/master/examples/java/struct-def).
+
 
 ## Dependencies
 

--- a/examples/wfrun-struct/README.md
+++ b/examples/wfrun-struct/README.md
@@ -1,0 +1,116 @@
+# WfRun Connector with StructDef
+
+In this example you will:
+
+- Define LittleHorse [StructDefs](https://littlehorse.io/docs/server/concepts/structs) (`Pilot` with a nested `Vehicle`).
+- Register a workflow with a `STRUCT` variable type.
+- Produce json messages to a kafka topic without SchemaRegistry.
+- Create a WfRunSinkConnector without transformations.
+
+> [!WARNING]
+> Run the commands in the root directory
+
+> [!IMPORTANT]
+> `StructDef`s are experimental in LittleHorse and **not yet supported by the Kafka
+> Connect sink connectors**. This example shows how to model and register the
+> `StructDef`s and a workflow that uses them. The connector configuration is included
+> for completeness, but passing a `Struct` as a `WfRun` variable through Kafka Connect
+> is not wired up yet. See the upstream
+> [struct-def example](https://github.com/littlehorse-enterprises/littlehorse/tree/master/examples/java/struct-def).
+
+## Dependencies
+
+- httpie
+- docker
+- java
+
+## Setup Environment
+
+Build plugin bundle:
+
+```shell
+./gradlew buildConfluentBundle
+```
+
+Run environment:
+
+```shell
+docker compose up -d
+```
+
+## Populate Topic
+
+Create topic:
+
+```shell
+docker compose exec kafka-connect \
+kafka-topics --create --bootstrap-server kafka1:9092 \
+--replication-factor 3 \
+--partitions 12 \
+--topic example-wfrun-struct
+```
+
+Produce:
+
+```shell
+docker compose exec -T kafka-connect \
+kafka-console-producer --bootstrap-server kafka1:9092 \
+--topic example-wfrun-struct \
+< examples/wfrun-struct/data.txt
+```
+
+Consume:
+
+> [!NOTE]
+> In case you need to verify the messages in the topic.
+
+```shell
+docker compose exec kafka-connect \
+kafka-console-consumer --bootstrap-server kafka1:9092 \
+--topic example-wfrun-struct \
+--from-beginning
+```
+
+> [!NOTE]
+> If you need to generate new data run:
+
+```shell
+./gradlew -q example-wfrun-struct:run -DmainClass="io.littlehorse.example.DataGenerator" --args="10" > examples/wfrun-struct/data.txt
+```
+
+## Run Worker
+
+Run worker (registers the `Vehicle` and `Pilot` `StructDef`s, the `TaskDef`, and the `WfSpec`):
+
+```shell
+./gradlew example-wfrun-struct:run
+```
+
+Verify the `StructDef`s were created:
+
+```shell
+lhctl get structDef example-wfrun-struct-pilot 0
+lhctl get structDef example-wfrun-struct-vehicle 0
+```
+
+## Create Connector
+
+Create connector:
+
+```shell
+http PUT :8083/connectors/example-wfrun-struct/config < examples/wfrun-struct/connector.json
+```
+
+Get connector:
+
+```shell
+http :8083/connectors/example-wfrun-struct
+```
+
+## Check WfRuns
+
+List WfRuns:
+
+```shell
+lhctl search wfRun example-wfrun-struct
+```

--- a/examples/wfrun-struct/build.gradle
+++ b/examples/wfrun-struct/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id "application"
+}
+
+dependencies {
+    // utils
+    implementation "net.datafaker:datafaker:${datafakerVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    implementation project(":common")
+
+    // littlehorse
+    implementation "io.littlehorse:littlehorse-client:${lhVersion}"
+
+    // log
+    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
+    implementation "org.slf4j:slf4j-simple:${slf4jVersion}"
+
+    // lombok
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testImplementation platform("org.junit:junit-bom:${junitVersion}")
+    testImplementation "org.junit.jupiter:junit-jupiter"
+}
+
+test {
+    useJUnitPlatform()
+}
+
+application {
+    mainClass = System.getProperty("mainClass", "io.littlehorse.example.Main")
+}
+
+compileJava {
+    options.compilerArgs << "-parameters"
+}

--- a/examples/wfrun-struct/connector.json
+++ b/examples/wfrun-struct/connector.json
@@ -1,0 +1,15 @@
+{
+  "tasks.max": 2,
+  "connector.class": "io.littlehorse.connect.WfRunSinkConnector",
+  "topics": "example-wfrun-struct",
+  "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "value.converter.schemas.enable": false,
+  "transforms": "HoistField",
+  "transforms.HoistField.type": "org.apache.kafka.connect.transforms.HoistField$Value",
+  "transforms.HoistField.field": "pilot",
+  "lhc.api.port": 2024,
+  "lhc.api.host": "littlehorse",
+  "lhc.tenant.id": "default",
+  "wf.spec.name": "example-wfrun-struct"
+}

--- a/examples/wfrun-struct/data.txt
+++ b/examples/wfrun-struct/data.txt
@@ -1,0 +1,10 @@
+{"name":"Luke Skywalker","vehicle":{"model":"Snowspeeder"}}
+{"name":"Han Solo","vehicle":{"model":"Millennium Falcon"}}
+{"name":"Anakin Skywalker","vehicle":{"model":"Jedi starfighter"}}
+{"name":"Leia Organa","vehicle":{"model":"Tantive IV"}}
+{"name":"Padme Amidala","vehicle":{"model":"Naboo Royal Starship"}}
+{"name":"Obi-Wan Kenobi","vehicle":{"model":"Jedi starfighter"}}
+{"name":"Boba Fett","vehicle":{"model":"Slave I"}}
+{"name":"Lando Calrissian","vehicle":{"model":"Millennium Falcon"}}
+{"name":"Wedge Antilles","vehicle":{"model":"X-wing"}}
+{"name":"Darth Vader","vehicle":{"model":"TIE Advanced x1"}}

--- a/examples/wfrun-struct/src/main/java/io/littlehorse/example/DataGenerator.java
+++ b/examples/wfrun-struct/src/main/java/io/littlehorse/example/DataGenerator.java
@@ -1,0 +1,22 @@
+package io.littlehorse.example;
+
+import net.datafaker.Faker;
+
+import java.util.stream.Stream;
+
+public class DataGenerator {
+
+    private static final Faker faker = new Faker();
+
+    public static void main(String[] args) {
+        int datasetSize = args.length > 0 ? Integer.parseInt(args[0]) : 10;
+        Stream.generate(DataGenerator::newPilot).limit(datasetSize).forEach(System.out::println);
+    }
+
+    private static Pilot newPilot() {
+        return Pilot.builder()
+                .name(faker.starWars().character())
+                .vehicle(Vehicle.builder().model(faker.starWars().vehicles()).build())
+                .build();
+    }
+}

--- a/examples/wfrun-struct/src/main/java/io/littlehorse/example/Main.java
+++ b/examples/wfrun-struct/src/main/java/io/littlehorse/example/Main.java
@@ -1,0 +1,58 @@
+package io.littlehorse.example;
+
+import io.littlehorse.sdk.common.config.LHConfig;
+import io.littlehorse.sdk.common.proto.StructDefCompatibilityType;
+import io.littlehorse.sdk.wfsdk.Workflow;
+import io.littlehorse.sdk.worker.LHTaskMethod;
+import io.littlehorse.sdk.worker.LHTaskWorker;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Main {
+
+    public static final String TASK_DEF_NAME = "example-wfrun-struct-greet";
+    public static final String WF_NAME = "example-wfrun-struct";
+    public static final String VARIABLE_PILOT = "pilot";
+
+    public static Workflow getWorkflow() {
+        return Workflow.newWorkflow(
+                WF_NAME,
+                wf -> wf.execute(TASK_DEF_NAME, wf.declareStruct(VARIABLE_PILOT, Pilot.class)));
+    }
+
+    private static LHTaskWorker getTaskWorker(LHConfig lhConfig) {
+        LHTaskWorker worker = new LHTaskWorker(new GreetingsWorker(), TASK_DEF_NAME, lhConfig);
+        Runtime.getRuntime().addShutdownHook(new Thread(worker::close));
+        return worker;
+    }
+
+    public static void main(String[] args) {
+        LHConfig lhConfig = new LHConfig();
+
+        LHTaskWorker worker = getTaskWorker(lhConfig);
+
+        // StructDefs must be registered before the TaskDef and WfSpec that use them.
+        // Dependencies first: Vehicle is nested inside Pilot.
+        worker.registerStructDef(Vehicle.class, StructDefCompatibilityType.NO_SCHEMA_UPDATES);
+        worker.registerStructDef(Pilot.class, StructDefCompatibilityType.NO_SCHEMA_UPDATES);
+
+        worker.registerTaskDef();
+
+        Workflow workflow = getWorkflow();
+        workflow.registerWfSpec(lhConfig.getBlockingStub());
+
+        worker.start();
+    }
+
+    public static class GreetingsWorker {
+
+        @LHTaskMethod(TASK_DEF_NAME)
+        public String greeting(Pilot pilot) {
+            String message = "Hello there! " + pilot.getName() + ", you're driving a "
+                    + pilot.getVehicle().getModel();
+            log.info(message);
+            return message;
+        }
+    }
+}

--- a/examples/wfrun-struct/src/main/java/io/littlehorse/example/Pilot.java
+++ b/examples/wfrun-struct/src/main/java/io/littlehorse/example/Pilot.java
@@ -1,0 +1,26 @@
+package io.littlehorse.example;
+
+import io.littlehorse.sdk.worker.LHStructDef;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@LHStructDef("example-wfrun-struct-pilot")
+public class Pilot {
+
+    private String name;
+    private Vehicle vehicle;
+
+    @Override
+    public String toString() {
+        return JsonSerializer.serialize(this);
+    }
+}

--- a/examples/wfrun-struct/src/main/java/io/littlehorse/example/Vehicle.java
+++ b/examples/wfrun-struct/src/main/java/io/littlehorse/example/Vehicle.java
@@ -1,0 +1,25 @@
+package io.littlehorse.example;
+
+import io.littlehorse.sdk.worker.LHStructDef;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@LHStructDef("example-wfrun-struct-vehicle")
+public class Vehicle {
+
+    private String model;
+
+    @Override
+    public String toString() {
+        return JsonSerializer.serialize(this);
+    }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -45,7 +45,7 @@
     "component_types": [
         "sink"
     ],
-    "release_date": "2026-06-24",
+    "release_date": "2026-06-25",
     "license": [
         {
             "name": "Server Side Public License, Version 1",

--- a/manifest.json
+++ b/manifest.json
@@ -45,7 +45,7 @@
     "component_types": [
         "sink"
     ],
-    "release_date": "2026-05-13",
+    "release_date": "2026-06-24",
     "license": [
         {
             "name": "Server Side Public License, Version 1",

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,7 @@ include "common"
 
 [
         "wfrun-json",
+        "wfrun-struct",
         "wfrun-dlq",
         "wfrun-simple",
         "wfrun-headers",

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,8 +29,10 @@ include "common"
         "external-event-json",
         "external-event-value-to-key",
         "external-event-simple",
+        "external-event-struct",
         "external-event-headers",
         "correlated-event-simple",
+        "correlated-event-struct",
         "correlated-event-json",
         "correlated-event-headers"
 ].each { example ->


### PR DESCRIPTION
## Summary

Adds StructDef content support across all three sink connectors and introduces transient vs. permanent error handling for more reliable delivery.

## Highlights

### Struct support for all connectors

- `WfRunSinkConnector`, `ExternalEventSinkConnector`, and `CorrelatedEventSinkConnector` now build native LittleHorse `STRUCT` values from kafka connect struct message payloads.
- Connectors read the relevant `WfSpec` / `ExternalEventDef` on startup to detect `STRUCT` types and resolve nested `StructDef`s automatically, with no extra configuration required.
- Shared logic extracted into a new `VariableValueMapper` with lazy, cached `StructDef` resolution, reused by all tasks.
- Connectors fail fast on startup if the referenced metadata cannot be loaded, instead of degrading silently.

### Transient vs. permanent error handling

- gRPC calls that fail with retriable status codes (`CANCELLED`, `DEADLINE_EXCEEDED`, `RESOURCE_EXHAUSTED`, `ABORTED`, `INTERNAL`, `UNAVAILABLE`) are now retried instead of being routed to the DLQ, protecting valid records from transient network or server issues.
- Permanent errors (e.g. `INVALID_ARGUMENT`, malformed payloads) continue to honor `errors.tolerance` and route to the DLQ.
- Add a new `transient.errors.tolerance` that allow you to modify the error handling behaviour.

closes: #54 
closes: #42

Assisted-by: Claude Opus 4.8