### PR TITLE
feat(connector): add partition and offset to JSONPath envelope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,8 +111,8 @@ Local stack:
   decides its meaning, but note the Kafka Connect REST API itself rejects a bare JSON `null` config
   value, so reaching this path means using the `null` literal text or a non-REST config source.
 - `JsonPathMapperTransform` builds the domain from scratch by evaluating JSONPath expressions
-  (values must start with `$`) against the record envelope `{key, value, headers}`; unmapped
-  fields are dropped. Functions such as `concat`/`sum` are supported.
+  (values must start with `$`) against the record envelope `{key, value, headers, partition,
+  offset}`; unmapped fields are dropped. Functions such as `concat`/`sum` are supported.
 - `LiteralMapperTransform` injects constant values whose type is inferred (int, double,
   `true`/`false`, `null`, else string; double-quote to force a string). Setting
   `implicit.casting.enabled=false` disables inference and keeps every value as its original

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,12 @@ Local stack:
   value, so reaching this path means using the `null` literal text or a non-REST config source.
 - `JsonPathMapperTransform` builds the domain from scratch by evaluating JSONPath expressions
   (values must start with `$`) against the record envelope `{key, value, headers, partition,
-  offset}`; unmapped fields are dropped. Functions such as `concat`/`sum` are supported.
+  offset}`; unmapped fields are dropped. Functions such as `concat`/`sum` are supported. The
+  envelope is populated by `util/JsonPathEvaluator`: `offset` is only set for `SinkRecord`s (it is
+  `null` on source records, which carry no Kafka offset) and `partition` is `null` when the record
+  has no assigned partition, so on source connectors only `$.key`/`$.value`/`$.headers` are
+  generally useful. The transform is a plain SMT, so it also runs on source connectors (see the
+  `source-json-path` example).
 - `LiteralMapperTransform` injects constant values whose type is inferred (int, double,
   `true`/`false`, `null`, else string; double-quote to force a string). Setting
   `implicit.casting.enabled=false` disables inference and keeps every value as its original

--- a/CONFIGURATIONS.md
+++ b/CONFIGURATIONS.md
@@ -387,7 +387,7 @@
 ## JsonPathFilterPredicate Configurations
 
 ``expression``
-  A JSONPath expression (starting with '$') evaluated against the record envelope {key, value, headers}. The record matches when the result is truthy: a true boolean, a non-empty match list or object, or any other non-null value (e.g. an existence check); it does not match when the result is null, false, or an empty match. Combine with the transform's 'negate' option to invert the result.
+  A JSONPath expression (starting with '$') evaluated against the record envelope {key, value, headers, partition, offset}. The record matches when the result is truthy: a true boolean, a non-empty match list or object, or any other non-null value (e.g. an existence check); it does not match when the result is null, false, or an empty match. Combine with the transform's 'negate' option to invert the result.
 
   * Type: string
   * Importance: high
@@ -395,7 +395,7 @@
 ## JsonPathMapperTransform Configurations
 
 ``mapping``
-  Defines a mapping written into the operating domain. Each mapping is its own property: the bare ``mapping`` targets the whole domain, while ``mapping.<path>`` (a dot-separated path such as ``mapping.pilot.vehicle.model``) builds nested objects; for the ``$Headers`` variant the whole path is a single, flat header name. The value must be a JSONPath expression (starting with '$') evaluated against the record envelope ``{key, value, headers}``, and functions such as ``concat`` and ``sum`` are supported. Use the ``$Key``, ``$Value`` or ``$Headers`` nested variant to choose whether the record key, value or headers are rebuilt. The operating domain is built from scratch, so unmapped fields are dropped.
+  Defines a mapping written into the operating domain. Each mapping is its own property: the bare ``mapping`` targets the whole domain, while ``mapping.<path>`` (a dot-separated path such as ``mapping.pilot.vehicle.model``) builds nested objects; for the ``$Headers`` variant the whole path is a single, flat header name. The value must be a JSONPath expression (starting with '$') evaluated against the record envelope ``{key, value, headers, partition, offset}``, and functions such as ``concat`` and ``sum`` are supported. Use the ``$Key``, ``$Value`` or ``$Headers`` nested variant to choose whether the record key, value or headers are rebuilt. The operating domain is built from scratch, so unmapped fields are dropped.
 
   * Type: string
   * Default: null

--- a/README.md
+++ b/README.md
@@ -421,8 +421,8 @@ nested objects (for the `$Headers` variant the whole path is a single, flat head
 ### JsonPathMapperTransform
 
 Builds the operating domain by evaluating JSONPath expressions (each value must start with `$`)
-against the record envelope `{key, value, headers}`. It is construct-only: fields that are not
-mapped are dropped. JSONPath functions such as `concat` and `sum` are supported.
+against the record envelope `{key, value, headers, partition, offset}`. It is construct-only:
+fields that are not mapped are dropped. JSONPath functions such as `concat` and `sum` are supported.
 
 ```json
 {
@@ -495,9 +495,9 @@ See the [wfrun-filter example](examples/wfrun-filter/README.md) for a complete s
 ### JsonPathFilterPredicate
 
 Matches a record by evaluating a JSONPath `expression` against the record envelope
-`{key, value, headers}`. Unlike `FilterByFieldPredicate` it has no `$Key`/`$Value` variant: the
-expression itself selects `$.key`, `$.value` or `$.headers`, so it can reach nested fields and does
-not require a `Struct`. A record matches when the result is truthy: a `true` boolean, a non-zero
+`{key, value, headers, partition, offset}`. Unlike `FilterByFieldPredicate` it has no `$Key`/`$Value`
+variant: the expression itself selects `$.key`, `$.value`, `$.headers`, `$.partition` or `$.offset`,
+so it can reach nested fields and does not require a `Struct`. A record matches when the result is truthy: a `true` boolean, a non-zero
 number, a non-empty string, or a non-empty match list or object (e.g. an inline filter `[?(...)]`);
 it does not match on `null`, `false`, `0`, an empty string, or an empty match.
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,16 @@ Builds the operating domain by evaluating JSONPath expressions (each value must 
 against the record envelope `{key, value, headers, partition, offset}`. It is construct-only:
 fields that are not mapped are dropped. JSONPath functions such as `concat` and `sum` are supported.
 
+The envelope exposes these fields, but not all of them carry a value on every connector type:
+
+| Path          | Description                        | Sink connectors                     | Source connectors                                    |
+| ------------- | ---------------------------------- | ----------------------------------- | ---------------------------------------------------- |
+| `$.key`       | Record key                         | Yes                                 | Yes                                                  |
+| `$.value`     | Record value                       | Yes                                 | Yes                                                  |
+| `$.headers`   | Map of header name to header value | Yes                                 | Yes                                                  |
+| `$.partition` | Kafka partition                    | Yes                                 | `null` unless the source sets a partition            |
+| `$.offset`    | Kafka offset                       | Yes                                 | `null` (only sink records carry a Kafka offset)      |
+
 ```json
 {
   "transforms": "WfRunVariablesMapper",
@@ -433,6 +443,11 @@ fields that are not mapped are dropped. JSONPath functions such as `concat` and 
   "transforms.WfRunVariablesMapper.mapping.summary": "$.concat($.value.title, \" by \", $.value.director)"
 }
 ```
+
+Although the LittleHorse connectors are sinks, this transform is a standard SMT and can run on a
+source connector too. See the [source-json-path example](examples/source-json-path/README.md) for a
+runnable setup, and the [wfrun-json-path-id example](examples/wfrun-json-path-id/README.md) for
+building a `WfRunId` from `$.partition` and `$.offset` on a sink connector.
 
 ### LiteralMapperTransform
 
@@ -495,9 +510,11 @@ See the [wfrun-filter example](examples/wfrun-filter/README.md) for a complete s
 ### JsonPathFilterPredicate
 
 Matches a record by evaluating a JSONPath `expression` against the record envelope
-`{key, value, headers, partition, offset}`. Unlike `FilterByFieldPredicate` it has no `$Key`/`$Value`
-variant: the expression itself selects `$.key`, `$.value`, `$.headers`, `$.partition` or `$.offset`,
-so it can reach nested fields and does not require a `Struct`. A record matches when the result is truthy: a `true` boolean, a non-zero
+`{key, value, headers, partition, offset}` (the same fields, with the same connector-type
+applicability, as the [JsonPathMapperTransform](#jsonpathmappertransform)). Unlike
+`FilterByFieldPredicate` it has no `$Key`/`$Value` variant: the expression itself selects `$.key`,
+`$.value`, `$.headers`, `$.partition` or `$.offset`, so it can reach nested fields and does not
+require a `Struct`. A record matches when the result is truthy: a `true` boolean, a non-zero
 number, a non-empty string, or a non-empty match list or object (e.g. an inline filter `[?(...)]`);
 it does not match on `null`, `false`, `0`, an empty string, or an empty match.
 

--- a/connector/src/main/java/io/littlehorse/connect/predicate/JsonPathFilterPredicate.java
+++ b/connector/src/main/java/io/littlehorse/connect/predicate/JsonPathFilterPredicate.java
@@ -18,7 +18,8 @@ import java.util.Map;
 
 /**
  * A {@link Predicate} that matches a record by evaluating a JSONPath expression against an
- * envelope of the record: {@code {key, value, headers}}. The record matches when the result is
+ * envelope of the record: {@code {key, value, headers, partition, offset}}. The record matches
+ * when the result is
  * truthy: a {@code true} boolean, a non-zero number, a non-empty string, a non-empty match list
  * or object, or any other non-null value. It does not match when the result is {@code null},
  * {@code false}, {@code 0}, an empty string, or an empty match.

--- a/connector/src/main/java/io/littlehorse/connect/predicate/JsonPathFilterPredicateConfig.java
+++ b/connector/src/main/java/io/littlehorse/connect/predicate/JsonPathFilterPredicateConfig.java
@@ -21,7 +21,8 @@ public class JsonPathFilterPredicateConfig extends AbstractConfig {
                     ConfigDef.NO_DEFAULT_VALUE,
                     Importance.HIGH,
                     "A JSONPath expression (starting with '$') evaluated against the record"
-                            + " envelope {key, value, headers}. The record matches when the result"
+                            + " envelope {key, value, headers, partition, offset}. The record"
+                            + " matches when the result"
                             + " is truthy: a true boolean, a non-empty match list or object, or any"
                             + " other non-null value (e.g. an existence check); it does not match"
                             + " when the result is null, false, or an empty match. Combine with the"

--- a/connector/src/main/java/io/littlehorse/connect/transform/JsonPathMapperTransform.java
+++ b/connector/src/main/java/io/littlehorse/connect/transform/JsonPathMapperTransform.java
@@ -15,7 +15,8 @@ import java.util.List;
 
 /**
  * Builds an operating domain (the record key, value, or headers) by evaluating JSONPath
- * expressions against an envelope of the record: {@code {key, value, headers}}. Mapping values
+ * expressions against an envelope of the record: {@code {key, value, headers, partition, offset}}.
+ * Mapping values
  * must be JSONPath expressions (they start with {@code $}); use {@link LiteralMapperTransform}
  * to inject constant values.
  */
@@ -28,7 +29,8 @@ public abstract class JsonPathMapperTransform<R extends ConnectRecord<R>>
                     + " dot-separated path such as ``mapping.pilot.vehicle.model``) builds nested"
                     + " objects; for the ``$Headers`` variant the whole path is a single, flat"
                     + " header name. The value must be a JSONPath expression (starting with '$')"
-                    + " evaluated against the record envelope ``{key, value, headers}``, and"
+                    + " evaluated against the record envelope ``{key, value, headers, partition,"
+                    + " offset}``, and"
                     + " functions such as ``concat`` and ``sum`` are supported. Use the ``$Key``,"
                     + " ``$Value`` or ``$Headers`` nested variant to choose whether the record key,"
                     + " value or headers are rebuilt. The operating domain is built from scratch, so"

--- a/connector/src/main/java/io/littlehorse/connect/util/JsonPathEvaluator.java
+++ b/connector/src/main/java/io/littlehorse/connect/util/JsonPathEvaluator.java
@@ -17,6 +17,10 @@ import java.util.Map;
  * {@code {key, value, headers, partition, offset}}. {@code Struct} values are flattened to plain
  * maps/lists so they can be navigated by JSONPath, and missing paths resolve to {@code null}
  * instead of throwing.
+ *
+ * <p>{@code offset} is only populated for {@link SinkRecord}s (source records carry no Kafka
+ * offset, so it resolves to {@code null}), and {@code partition} is {@code null} whenever the
+ * record has no assigned partition.
  */
 public final class JsonPathEvaluator {
 

--- a/connector/src/main/java/io/littlehorse/connect/util/JsonPathEvaluator.java
+++ b/connector/src/main/java/io/littlehorse/connect/util/JsonPathEvaluator.java
@@ -7,20 +7,24 @@ import com.jayway.jsonpath.Option;
 
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Parses a record into a JSONPath {@link DocumentContext} backed by an envelope of the record:
- * {@code {key, value, headers}}. {@code Struct} values are flattened to plain maps/lists so they
- * can be navigated by JSONPath, and missing paths resolve to {@code null} instead of throwing.
+ * {@code {key, value, headers, partition, offset}}. {@code Struct} values are flattened to plain
+ * maps/lists so they can be navigated by JSONPath, and missing paths resolve to {@code null}
+ * instead of throwing.
  */
 public final class JsonPathEvaluator {
 
     private static final String KEY_DOMAIN = "key";
     private static final String VALUE_DOMAIN = "value";
     private static final String HEADERS_DOMAIN = "headers";
+    private static final String PARTITION_DOMAIN = "partition";
+    private static final String OFFSET_DOMAIN = "offset";
 
     private static final Configuration CONFIG = Configuration.builder()
             .options(Option.SUPPRESS_EXCEPTIONS, Option.DEFAULT_PATH_LEAF_TO_NULL)
@@ -37,6 +41,10 @@ public final class JsonPathEvaluator {
         envelope.put(KEY_DOMAIN, objectMapper.removeStruct(record.key()));
         envelope.put(VALUE_DOMAIN, objectMapper.removeStruct(record.value()));
         envelope.put(HEADERS_DOMAIN, headersToMap(record.headers()));
+        envelope.put(PARTITION_DOMAIN, record.kafkaPartition());
+        envelope.put(
+                OFFSET_DOMAIN,
+                record instanceof SinkRecord ? ((SinkRecord) record).kafkaOffset() : null);
         return envelope;
     }
 

--- a/connector/src/test/java/e2e/tests/RunWorkflowsJsonPathWfRunIdTest.java
+++ b/connector/src/test/java/e2e/tests/RunWorkflowsJsonPathWfRunIdTest.java
@@ -1,0 +1,81 @@
+package e2e.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import e2e.configs.E2ETest;
+
+import io.littlehorse.sdk.common.proto.LHStatus;
+import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
+import io.littlehorse.sdk.common.proto.SearchWfRunRequest;
+import io.littlehorse.sdk.common.proto.WfRunId;
+import io.littlehorse.sdk.common.proto.WfRunIdList;
+import io.littlehorse.sdk.wfsdk.Workflow;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+/**
+ * Uses the {@code JsonPathMapperTransform} together with the {@code WfRunSinkConnector} to build a
+ * custom {@code WfRunId} from the record's Kafka {@code partition} and {@code offset} exposed in
+ * the JSONPath envelope. Each record started with an id such as {@code p<partition>-o<offset>}.
+ */
+public class RunWorkflowsJsonPathWfRunIdTest extends E2ETest {
+
+    public static final String WORKFLOW_NAME = "json-path-mapper-wf-run-id";
+    public static final String CONNECTOR_NAME = "json-path-mapper-wf-run-id";
+    private static final String INPUT_TOPIC = "json-path-mapper-wf-run-id";
+    private static final Workflow WORKFLOW = Workflow.newWorkflow(WORKFLOW_NAME, wf -> {
+        wf.declareStr("name");
+        wf.sleepSeconds(1);
+    });
+    private final LittleHorseBlockingStub lhClient = getLittleHorseConfig().getBlockingStub();
+
+    @Test
+    public void shouldBuildWfRunIdFromPartitionAndOffset() {
+        registerWorkflow(WORKFLOW);
+        createTopics(INPUT_TOPIC);
+        // The topic has a single partition, so records land on partition 0 with offsets 0, 1, 2.
+        produceValues(
+                INPUT_TOPIC,
+                KafkaMessage.of("{\"name\":\"Han Solo\"}"),
+                KafkaMessage.of("{\"name\":\"Leia Organa\"}"),
+                KafkaMessage.of("{\"name\":\"Luke Skywalker\"}"));
+        registerConnector(CONNECTOR_NAME, getConnectorConfig());
+
+        await(() -> {
+            SearchWfRunRequest criteria = SearchWfRunRequest.newBuilder()
+                    .setStatus(LHStatus.COMPLETED)
+                    .setWfSpecName(WORKFLOW_NAME)
+                    .build();
+            WfRunIdList result = lhClient.searchWfRun(criteria);
+            assertThat(result.getResultsList())
+                    .contains(
+                            WfRunId.newBuilder().setId("p0-o0").build(),
+                            WfRunId.newBuilder().setId("p0-o1").build(),
+                            WfRunId.newBuilder().setId("p0-o2").build());
+        });
+    }
+
+    private static HashMap<String, Object> getConnectorConfig() {
+        HashMap<String, Object> connectorConfig = new HashMap<>();
+        connectorConfig.put("tasks.max", 1);
+        connectorConfig.put("connector.class", "io.littlehorse.connect.WfRunSinkConnector");
+        connectorConfig.put("topics", INPUT_TOPIC);
+        connectorConfig.put("key.converter", "org.apache.kafka.connect.storage.StringConverter");
+        connectorConfig.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
+        connectorConfig.put("value.converter.schemas.enable", false);
+        connectorConfig.put("transforms", "wfRunIdMapper");
+        connectorConfig.put(
+                "transforms.wfRunIdMapper.type",
+                "io.littlehorse.connect.transform.JsonPathMapperTransform$Headers");
+        connectorConfig.put(
+                "transforms.wfRunIdMapper.mapping.wfRunId",
+                "$.concat(\"p\", $.partition, \"-o\", $.offset)");
+        connectorConfig.put("lhc.api.port", 2023);
+        connectorConfig.put("lhc.api.host", "littlehorse");
+        connectorConfig.put("lhc.tenant.id", "default");
+        connectorConfig.put("wf.spec.name", WORKFLOW_NAME);
+        return connectorConfig;
+    }
+}

--- a/connector/src/test/java/io/littlehorse/connect/transform/JsonPathMapperTransformTest.java
+++ b/connector/src/test/java/io/littlehorse/connect/transform/JsonPathMapperTransformTest.java
@@ -91,6 +91,28 @@ class JsonPathMapperTransformTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void shouldMapPartitionAndOffsetFromEnvelope() {
+        Map<String, Object> value = new HashMap<>();
+        value.put("id", "ord-789");
+
+        SinkRecord record = new SinkRecord(TOPIC, 3, null, null, null, value, 42);
+
+        JsonPathMapperTransform.Value<SinkRecord> mapper = new JsonPathMapperTransform.Value<>();
+        mapper.configure(Map.of(
+                MAPPING_PREFIX + "partition", "$.partition",
+                MAPPING_PREFIX + "offset", "$.offset"));
+
+        SinkRecord result = mapper.apply(record);
+
+        Map<String, Object> resultValue = (Map<String, Object>) result.value();
+        assertThat(resultValue.get("partition")).isEqualTo(3);
+        assertThat(resultValue.get("offset")).isEqualTo(42L);
+
+        mapper.close();
+    }
+
+    @Test
     void shouldBuildHeadersFromMappings() {
         Map<String, Object> value = new HashMap<>();
         value.put("id", "ord-789");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,7 @@ services:
       - ./connector/build/bundle:/usr/local/share/kafka/plugins:ro
       - ./examples/wfrun-secrets/secrets.properties:/home/appuser/secrets.properties:ro
       - ./examples/apicurio-json-schema-source-sink:/data:ro
+      - ./examples/source-json-path:/data-json-path:ro
 
   apicurio:
     image: apicurio/apicurio-registry:${APICURIO_VERSION}

--- a/examples/source-json-path/README.md
+++ b/examples/source-json-path/README.md
@@ -1,0 +1,65 @@
+# JSONPath Transform on a Source Connector
+
+This example shows that the `JsonPathMapperTransform` is a standard Single Message Transform, so it
+works on **source** connectors too, not just the LittleHorse sink connectors.
+
+- A `FileStreamSourceConnector` reads plain-text lines from a file and emits each line as a string
+  value.
+- A [`JsonPathMapperTransform$Value`](../../CONFIGURATIONS.md) reshapes every record's value into a
+  structured object `{"quote": "<line>"}` by reading `$.value` from the record envelope.
+- The `JsonConverter` then serializes that object as JSON on the topic.
+
+> [!NOTE]
+> The transform evaluates its expressions against the record envelope
+> `{key, value, headers, partition, offset}`. On a **source** record `offset` is always `null` and
+> `partition` is `null` unless the source sets it, so only `$.key`, `$.value` and `$.headers` are
+> generally useful here. See the [transforms documentation](../../README.md#transforms) for the
+> full field applicability.
+
+> [!WARNING]
+> Run the commands in the root directory
+
+## Dependencies
+
+- httpie
+- docker
+
+## Setup Environment
+
+Build plugin bundle:
+
+```shell
+./gradlew buildConfluentBundle
+```
+
+Run environment:
+
+```shell
+./gradlew dockerComposeUp
+```
+
+## Create the Source Connector
+
+Reads `quotes.txt` (mounted at `/data-json-path/quotes.txt`) and produces the reshaped JSON records
+to the topic:
+
+```shell
+http PUT :8083/connectors/example-source-json-path/config < examples/source-json-path/source-connector.json
+```
+
+Get connector:
+
+```shell
+http :8083/connectors/example-source-json-path
+```
+
+## Verify the Output
+
+Each line becomes a JSON object `{"quote":"<line>"}` on the topic:
+
+```shell
+docker compose exec kafka-connect \
+kafka-console-consumer --bootstrap-server kafka1:9092 \
+--topic example-source-json-path \
+--from-beginning
+```

--- a/examples/source-json-path/quotes.txt
+++ b/examples/source-json-path/quotes.txt
@@ -1,0 +1,5 @@
+May the Force be with you
+These are not the droids you are looking for
+I find your lack of faith disturbing
+Do. Or do not. There is no try
+The garbage will do

--- a/examples/source-json-path/source-connector.json
+++ b/examples/source-json-path/source-connector.json
@@ -1,0 +1,12 @@
+{
+  "connector.class": "org.apache.kafka.connect.file.FileStreamSourceConnector",
+  "tasks.max": 1,
+  "file": "/data-json-path/quotes.txt",
+  "topic": "example-source-json-path",
+  "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "value.converter.schemas.enable": false,
+  "transforms": "QuoteMapper",
+  "transforms.QuoteMapper.type": "io.littlehorse.connect.transform.JsonPathMapperTransform$Value",
+  "transforms.QuoteMapper.mapping.quote": "$.value"
+}

--- a/examples/wfrun-json-path-id/README.md
+++ b/examples/wfrun-json-path-id/README.md
@@ -1,0 +1,110 @@
+# WfRun Connector with a Custom WfRunId from Partition and Offset
+
+In this example you will:
+
+- Register a workflow with variable types: `STR`.
+- Produce JSON messages to a kafka topic without SchemaRegistry.
+- Create a `WfRunSinkConnector` with a `JsonPathMapperTransform$Headers` transform that derives the
+  `wfRunId` header from the record's Kafka `partition` and `offset`.
+
+The connector builds each `WfRunId` from a constant connector-name prefix plus the JSONPath
+envelope fields `$.partition` and `$.offset`, producing ids such as
+`example-wfrun-json-path-id-p<partition>-o<offset>` (for example
+`example-wfrun-json-path-id-p3-o42`). Because a partition/offset pair is unique per topic, this
+yields a deterministic, idempotent id per record.
+
+> [!WARNING]
+> Run the commands in the root directory
+
+## Dependencies
+
+- httpie
+- docker
+- java
+
+## Setup Environment
+
+Build plugin bundle:
+
+```shell
+./gradlew buildConfluentBundle
+```
+
+Run environment:
+
+```shell
+./gradlew dockerComposeUp
+```
+
+## Populate Topic
+
+Create topic:
+
+```shell
+docker compose exec kafka-connect \
+kafka-topics --create --bootstrap-server kafka1:9092 \
+--replication-factor 3 \
+--partitions 12 \
+--topic example-wfrun-json-path-id
+```
+
+Produce:
+
+```shell
+docker compose exec -T kafka-connect \
+kafka-console-producer --bootstrap-server kafka1:9092 \
+--topic example-wfrun-json-path-id \
+< examples/wfrun-json-path-id/data.txt
+```
+
+Consume:
+
+> [!NOTE]
+> In case you need to verify the messages in the topic.
+
+```shell
+docker compose exec kafka-connect \
+kafka-console-consumer --bootstrap-server kafka1:9092 \
+--topic example-wfrun-json-path-id \
+--from-beginning
+```
+
+> [!NOTE]
+> If you need to generate new data run:
+
+```shell
+./gradlew -q example-wfrun-json-path-id:run -DmainClass="io.littlehorse.example.DataGenerator" --args="10" > examples/wfrun-json-path-id/data.txt
+```
+
+## Run Worker
+
+Run worker:
+
+```shell
+./gradlew example-wfrun-json-path-id:run
+```
+
+## Create Connector
+
+Create connector:
+
+```shell
+http PUT :8083/connectors/example-wfrun-json-path-id/config < examples/wfrun-json-path-id/connector.json
+```
+
+Get connector:
+
+```shell
+http :8083/connectors/example-wfrun-json-path-id
+```
+
+## Check WfRuns
+
+List WfRuns:
+
+```shell
+lhctl search wfRun example-wfrun-json-path-id
+```
+
+The `WfRunId` of each run matches the `example-wfrun-json-path-id-p<partition>-o<offset>` of the
+record that started it.

--- a/examples/wfrun-json-path-id/build.gradle
+++ b/examples/wfrun-json-path-id/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id "application"
+}
+
+dependencies {
+    // utils
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    implementation project(":examples-common")
+
+    // littlehorse
+    implementation "io.littlehorse:littlehorse-client:${version}"
+
+    // log
+    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
+    implementation "org.slf4j:slf4j-simple:${slf4jVersion}"
+
+    // lombok
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testImplementation platform("org.junit:junit-bom:${junitVersion}")
+    testImplementation "org.junit.jupiter:junit-jupiter"
+}
+
+test {
+    useJUnitPlatform()
+}
+
+application {
+    mainClass = System.getProperty("mainClass", "io.littlehorse.example.Main")
+}
+
+compileJava {
+    options.compilerArgs << "-parameters"
+}

--- a/examples/wfrun-json-path-id/connector.json
+++ b/examples/wfrun-json-path-id/connector.json
@@ -1,0 +1,15 @@
+{
+  "tasks.max": 2,
+  "connector.class": "io.littlehorse.connect.WfRunSinkConnector",
+  "topics": "example-wfrun-json-path-id",
+  "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "value.converter.schemas.enable": false,
+  "transforms": "WfRunIdMapper",
+  "transforms.WfRunIdMapper.type": "io.littlehorse.connect.transform.JsonPathMapperTransform$Headers",
+  "transforms.WfRunIdMapper.mapping.wfRunId": "$.concat(\"example-wfrun-json-path-id-\", \"p\", $.partition, \"-o\", $.offset)",
+  "lhc.api.port": 2024,
+  "lhc.api.host": "littlehorse",
+  "lhc.tenant.id": "default",
+  "wf.spec.name": "example-wfrun-json-path-id"
+}

--- a/examples/wfrun-json-path-id/data.txt
+++ b/examples/wfrun-json-path-id/data.txt
@@ -1,0 +1,10 @@
+{"name":"Han Solo"}
+{"name":"Saw Gerrera"}
+{"name":"Luke Skywalker"}
+{"name":"Wilhuff Tarkin"}
+{"name":"Leia Organa"}
+{"name":"Lando Calrissian"}
+{"name":"Chewbacca"}
+{"name":"Cassian Andor"}
+{"name":"Din Djarin"}
+{"name":"Boba Fett"}

--- a/examples/wfrun-json-path-id/src/main/java/io/littlehorse/example/Character.java
+++ b/examples/wfrun-json-path-id/src/main/java/io/littlehorse/example/Character.java
@@ -1,0 +1,20 @@
+package io.littlehorse.example;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Character {
+
+    private String name;
+
+    @Override
+    public String toString() {
+        return JsonSerializer.serialize(this);
+    }
+}

--- a/examples/wfrun-json-path-id/src/main/java/io/littlehorse/example/DataGenerator.java
+++ b/examples/wfrun-json-path-id/src/main/java/io/littlehorse/example/DataGenerator.java
@@ -1,0 +1,19 @@
+package io.littlehorse.example;
+
+import java.util.stream.Stream;
+
+public class DataGenerator {
+
+    public static void main(String[] args) {
+        int datasetSize = args.length > 0 ? Integer.parseInt(args[0]) : 10;
+        Stream.generate(DataGenerator::newCharacter)
+                .limit(datasetSize)
+                .forEach(System.out::println);
+    }
+
+    private static Character newCharacter() {
+        return Character.builder()
+                .name(SampleData.starWars().character().fullName())
+                .build();
+    }
+}

--- a/examples/wfrun-json-path-id/src/main/java/io/littlehorse/example/Main.java
+++ b/examples/wfrun-json-path-id/src/main/java/io/littlehorse/example/Main.java
@@ -1,0 +1,51 @@
+package io.littlehorse.example;
+
+import io.littlehorse.sdk.common.config.LHConfig;
+import io.littlehorse.sdk.wfsdk.Workflow;
+import io.littlehorse.sdk.worker.LHTaskMethod;
+import io.littlehorse.sdk.worker.LHTaskWorker;
+import io.littlehorse.sdk.worker.WorkerContext;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Main {
+
+    public static final String TASK_DEF_NAME = "example-wfrun-json-path-id-greet";
+    public static final String WF_NAME = "example-wfrun-json-path-id";
+    public static final String VARIABLE_NAME = "name";
+
+    public static Workflow getWorkflow() {
+        return Workflow.newWorkflow(
+                WF_NAME, wf -> wf.execute(TASK_DEF_NAME, wf.declareStr(VARIABLE_NAME)));
+    }
+
+    private static LHTaskWorker getTaskWorker(LHConfig lhConfig) {
+        LHTaskWorker worker = new LHTaskWorker(new GreetingsWorker(), TASK_DEF_NAME, lhConfig);
+        Runtime.getRuntime().addShutdownHook(new Thread(worker::close));
+        return worker;
+    }
+
+    public static void main(String[] args) {
+        LHConfig lhConfig = new LHConfig();
+
+        LHTaskWorker worker = getTaskWorker(lhConfig);
+        worker.registerTaskDef();
+
+        Workflow workflow = getWorkflow();
+        workflow.registerWfSpec(lhConfig.getBlockingStub());
+
+        worker.start();
+    }
+
+    public static class GreetingsWorker {
+
+        @LHTaskMethod(TASK_DEF_NAME)
+        public String greeting(String name, WorkerContext context) {
+            String message = "Hello there! " + name + ". My wfRunId is: "
+                    + context.getWfRunId().getId();
+            log.info(message);
+            return message;
+        }
+    }
+}


### PR DESCRIPTION
Expose the record's Kafka partition and offset in the JSONPath envelope used by JsonPathMapperTransform and JsonPathFilterPredicate, and add the wfrun-json-path-id example that builds a custom WfRunId from them.

Assisted-by: Claude Opus 4.8